### PR TITLE
dynamic routes

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -31,7 +31,7 @@ export class Dispatcher {
       method,
       currentPath
     )({
-      path: parts.slice(remainingParts).join("/"),
+      path: String(parts.slice(remainingParts).join("/")),
 
       reduce: (reducer) => {
         this.registry.store = reducer(this.registry.store);

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,6 +1,8 @@
 export class Registry {
   modules = {};
 
+  moduleTree = {};
+
   store;
 
   constructor(store = {}) {
@@ -13,6 +15,7 @@ export class Registry {
 
   add(path, script) {
     this.modules[path] = script;
+    this.moduleTree[path.slice(1)] = {};
   }
 
   remove(path) {

--- a/src/registry.js
+++ b/src/registry.js
@@ -13,9 +13,27 @@ export class Registry {
     return Object.keys(this.modules);
   }
 
-  add(path, script) {
-    this.modules[path] = script;
-    this.moduleTree[path.slice(1)] = {};
+  add(url, script) {
+    this.modules[url] = script;
+
+    function addToTree(tree, path) {
+      if (path.length === 1) {
+        return {
+          ...tree,
+          [path[0]]: { ...tree[path[0]], script },
+        };
+      }
+
+      return {
+        ...tree,
+
+        [path[0]]: {
+          children: addToTree(tree[path[0]]?.children ?? {}, path.slice(1)),
+        },
+      };
+    }
+
+    this.moduleTree = addToTree(this.moduleTree, url.split("/").slice(1));
   }
 
   remove(path) {

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,3 +1,5 @@
+import { deepestAcceptableNodeInPath } from "./tree-functions.js";
+
 export class Registry {
   modules = {};
 
@@ -20,7 +22,7 @@ export class Registry {
   add(url, script) {
     this.modules[url] = script;
 
-    // const this.tree = withNode(this.tree, url.split('/').slice(1), node => {...node, module})
+    // const this.tree = withNode(this.tree, url.split('/').slice, node => {...node, module})
 
     function addModuleToTreeAtPath(module, tree, path) {
       const [nodeName] = path;
@@ -115,5 +117,16 @@ export class Registry {
       url.split("/").slice(1),
       notFoundFallback
     );
+  }
+
+  endpoint2(method, url) {
+    const targetNode = deepestAcceptableNodeInPath({
+      tree: this.moduleTree,
+      path: url.split("/").slice(1),
+      isAcceptable: (node) => node.script?.[method],
+      findChild: (tree, nodeName) => tree.children?.[nodeName],
+    });
+
+    return targetNode.script?.[method];
   }
 }

--- a/src/registry.js
+++ b/src/registry.js
@@ -20,7 +20,7 @@ export class Registry {
   add(url, script) {
     this.modules[url] = script;
 
-    function decorateTree(path, tree) {
+    function addModuleToTreeAtPath(module, tree, path) {
       const [nodeName] = path;
 
       const dynamicPathVariableName =
@@ -49,15 +49,20 @@ export class Registry {
         children: {
           ...tree.children,
 
-          [nodeName]: decorateTree(
-            path.slice(1),
-            tree?.children?.[nodeName] ?? {}
+          [nodeName]: addModuleToTreeAtPath(
+            module,
+            tree?.children?.[nodeName] ?? {},
+            path.slice(1)
           ),
         },
       };
     }
 
-    this.moduleTree = decorateTree(url.split("/").slice(1), this.moduleTree);
+    this.moduleTree = addModuleToTreeAtPath(
+      script,
+      this.moduleTree,
+      url.split("/").slice(1)
+    );
   }
 
   remove(path) {

--- a/src/registry.js
+++ b/src/registry.js
@@ -50,7 +50,10 @@ export class Registry {
   }
 
   endpoint(method, url) {
-    function findHandler(tree, path, fallback) {
+    function findHandler(tree, staticPath, fallback) {
+      const path = tree[staticPath[0]]
+        ? staticPath
+        : ["[user_id]", ...staticPath.slice(1)];
       const node = tree[path[0]];
 
       const handler = node?.script?.[method] ?? fallback;
@@ -63,7 +66,8 @@ export class Registry {
         return findHandler(node.children, path.slice(1), handler);
       }
 
-      return handler;
+      return (context) =>
+        handler({ ...context, pathParameters: { user_id: 123 } });
     }
 
     function notFoundFallback() {

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,7 +1,9 @@
 export class Registry {
   modules = {};
 
-  moduleTree = {};
+  moduleTree = {
+    children: {},
+  };
 
   store;
 
@@ -18,7 +20,7 @@ export class Registry {
   add(url, script) {
     this.modules[url] = script;
 
-    function addToTree(tree, path) {
+    function addToTree(path, tree) {
       const [nodeName] = path;
 
       const dynamicPathName =
@@ -43,12 +45,15 @@ export class Registry {
 
         [nodeName]: {
           ...tree[nodeName],
-          children: addToTree(tree[nodeName]?.children ?? {}, path.slice(1)),
+          children: addToTree(path.slice(1), tree[nodeName]?.children ?? {}),
         },
       };
     }
 
-    this.moduleTree = addToTree(this.moduleTree, url.split("/").slice(1));
+    this.moduleTree.children = addToTree(
+      url.split("/").slice(1),
+      this.moduleTree.children
+    );
   }
 
   remove(path) {
@@ -93,7 +98,7 @@ export class Registry {
     }
 
     return findHandler(
-      { children: this.moduleTree },
+      this.moduleTree,
       url.split("/").slice(1),
       notFoundFallback
     );

--- a/src/registry.js
+++ b/src/registry.js
@@ -20,6 +20,8 @@ export class Registry {
   add(url, script) {
     this.modules[url] = script;
 
+    // const this.tree = withNode(this.tree, url.split('/').slice(1), node => {...node, module})
+
     function addModuleToTreeAtPath(module, tree, path) {
       const [nodeName] = path;
 

--- a/src/registry.js
+++ b/src/registry.js
@@ -23,13 +23,13 @@ export class Registry {
     function decorateTree(path, tree) {
       const [nodeName] = path;
 
-      const dynamicPathName =
+      const dynamicPathVariableName =
         nodeName.startsWith("[") && nodeName.endsWith("]")
           ? nodeName.slice(1, -1)
           : undefined;
 
-      if (dynamicPathName) {
-        tree.dynamicPathName = dynamicPathName;
+      if (dynamicPathVariableName) {
+        tree.dynamicPathVariableName = dynamicPathVariableName;
       }
 
       if (path.length === 1) {
@@ -72,7 +72,7 @@ export class Registry {
     function findHandler(parentNode, path, fallback) {
       const nodeName = parentNode.children[path[0]]
         ? path[0]
-        : `[${parentNode.dynamicPathName}]`;
+        : `[${parentNode.dynamicPathVariableName}]`;
       const node = parentNode.children[nodeName];
 
       // probably extract this to findBestMatchHandler(node, method, fallback)
@@ -81,7 +81,7 @@ export class Registry {
         ? (context) =>
             matchingHandler({
               ...context,
-              pathParameters: { [nodeName.slice(1, -1)]: 123 },
+              pathParameters: { [nodeName.slice(1, -1)]: path[0] },
             })
         : fallback;
 

--- a/src/tree-functions.js
+++ b/src/tree-functions.js
@@ -1,0 +1,25 @@
+export function deepestAcceptableNodeInPath({
+  tree,
+  path,
+  isAcceptable,
+  findChild,
+}) {
+  if (path.length === 0) {
+    return tree;
+  }
+
+  const [head, ...tail] = path;
+
+  const child = findChild(tree, head);
+
+  if (child !== undefined && isAcceptable(child)) {
+    return deepestAcceptableNodeInPath({
+      tree: child,
+      path: tail,
+      isAcceptable,
+      findChild,
+    });
+  }
+
+  return tree;
+}

--- a/src/tree-functions.js
+++ b/src/tree-functions.js
@@ -5,21 +5,19 @@ export function deepestAcceptableNodeInPath({
   findChild,
 }) {
   if (path.length === 0) {
-    return tree;
+    return isAcceptable(tree) ? tree : undefined;
   }
 
   const [head, ...tail] = path;
 
   const child = findChild(tree, head);
 
-  if (child !== undefined && isAcceptable(child)) {
-    return deepestAcceptableNodeInPath({
+  return (
+    deepestAcceptableNodeInPath({
       tree: child,
       path: tail,
       isAcceptable,
       findChild,
-    });
-  }
-
-  return tree;
+    }) ?? tree
+  );
 }

--- a/test/counterfact.test.js
+++ b/test/counterfact.test.js
@@ -13,7 +13,7 @@ describe("integration test", () => {
       "hello.mjs": `
         export async function GET() {
           return await Promise.resolve({ body: "GET /hello" });
-        }
+        } 
       `,
       "hello/world.mjs": `
         export async function POST() {

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -78,33 +78,35 @@ describe("a scripted server", () => {
     registry.add("/foo", { GET: "GET /foo" });
 
     expect(registry.moduleTree).toStrictEqual({
-      foo: {
-        script: {
-          GET: "GET /foo",
-        },
+      children: {
+        foo: {
+          script: {
+            GET: "GET /foo",
+          },
 
-        children: {
-          bar: {
-            children: {
-              baz: {
-                script: {
-                  GET: "GET /foo/bar/baz",
+          children: {
+            bar: {
+              children: {
+                baz: {
+                  script: {
+                    GET: "GET /foo/bar/baz",
+                  },
                 },
-              },
 
-              bop: {
-                script: {
-                  GET: "GET /foo/bar/bop",
+                bop: {
+                  script: {
+                    GET: "GET /foo/bar/bop",
+                  },
                 },
               },
             },
           },
         },
-      },
 
-      bar: {
-        script: {
-          GET: "GET /bar",
+        bar: {
+          script: {
+            GET: "GET /bar",
+          },
         },
       },
     });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -6,7 +6,9 @@ describe("a scripted server", () => {
 
     registry.add("/hello", {
       async GET() {
-        return await Promise.resolve({ body: "hello" });
+        await Promise.resolve("noop");
+
+        return { body: "hello" };
       },
     });
 
@@ -22,20 +24,28 @@ describe("a scripted server", () => {
 
     registry.add("/a", {
       async GET() {
-        return await Promise.resolve({ body: "GET a" });
+        await Promise.resolve("noop");
+
+        return { body: "GET a" };
       },
 
       async POST() {
-        return await Promise.resolve({ body: "POST a" });
+        await Promise.resolve("noop");
+
+        return { body: "POST a" };
       },
     });
     registry.add("/b", {
       async GET() {
-        return await Promise.resolve({ body: "GET b" });
+        await Promise.resolve("noop");
+
+        return { body: "GET b" };
       },
 
       async POST() {
-        return await Promise.resolve({ body: "POST b" });
+        await Promise.resolve("noop");
+
+        return { body: "POST b" };
       },
     });
 

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -69,15 +69,40 @@ describe("a scripted server", () => {
     expect(postB.body).toBe("POST b");
   });
 
-  it("creates a module tree", () => {
+  it("builds a module tree", () => {
     const registry = new Registry();
 
-    registry.add("/foo", {});
-    registry.add("/bar", {});
+    registry.add("/foo", { GET: "GET foo" });
+    registry.add("/bar", { GET: "GET bar" });
+    registry.add("/foo/bar/baz", { GET: "GET foo/bar/baz" });
+    registry.add("/foo/bar/bop", { GET: "GET foo/bar/bop" });
 
     expect(registry.moduleTree).toStrictEqual({
-      foo: {},
-      bar: {},
+      foo: {
+        children: {
+          bar: {
+            children: {
+              baz: {
+                script: {
+                  GET: "GET foo/bar/baz",
+                },
+              },
+
+              bop: {
+                script: {
+                  GET: "GET foo/bar/bop",
+                },
+              },
+            },
+          },
+        },
+      },
+
+      bar: {
+        script: {
+          GET: "GET bar",
+        },
+      },
     });
   });
 

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -72,25 +72,29 @@ describe("a scripted server", () => {
   it("builds a module tree", () => {
     const registry = new Registry();
 
-    registry.add("/foo", { GET: "GET foo" });
-    registry.add("/bar", { GET: "GET bar" });
-    registry.add("/foo/bar/baz", { GET: "GET foo/bar/baz" });
-    registry.add("/foo/bar/bop", { GET: "GET foo/bar/bop" });
+    registry.add("/bar", { GET: "GET /bar" });
+    registry.add("/foo/bar/baz", { GET: "GET /foo/bar/baz" });
+    registry.add("/foo/bar/bop", { GET: "GET /foo/bar/bop" });
+    registry.add("/foo", { GET: "GET /foo" });
 
     expect(registry.moduleTree).toStrictEqual({
       foo: {
+        script: {
+          GET: "GET /foo",
+        },
+
         children: {
           bar: {
             children: {
               baz: {
                 script: {
-                  GET: "GET foo/bar/baz",
+                  GET: "GET /foo/bar/baz",
                 },
               },
 
               bop: {
                 script: {
-                  GET: "GET foo/bar/bop",
+                  GET: "GET /foo/bar/bop",
                 },
               },
             },
@@ -100,18 +104,18 @@ describe("a scripted server", () => {
 
       bar: {
         script: {
-          GET: "GET bar",
+          GET: "GET /bar",
         },
       },
     });
   });
 
-  it.skip("handles dynamic routes", async () => {
+  it("handles dynamic routes", async () => {
     const registry = new Registry();
 
-    registry.add("/user/[userid]", {
+    registry.add("/user/[user_id]", {
       GET() {
-        return { body: "GET userid" };
+        return { body: "GET user_id" };
       },
     });
 
@@ -124,8 +128,8 @@ describe("a scripted server", () => {
 
       store: {},
     };
-    const response = await registry.endpoint("GET", "/user/123")(context);
+    const response = await registry.endpoint("GET", "/user/[user_id]")(context);
 
-    expect(response).toBe("GET userid");
+    expect(response).toStrictEqual({ body: "GET user_id" });
   });
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -114,8 +114,8 @@ describe("a scripted server", () => {
     const registry = new Registry();
 
     registry.add("/user/[user_id]", {
-      GET() {
-        return { body: "GET user_id" };
+      GET({ pathParameters = {} }) {
+        return { body: `user ${pathParameters.user_id}` };
       },
     });
 
@@ -128,8 +128,8 @@ describe("a scripted server", () => {
 
       store: {},
     };
-    const response = await registry.endpoint("GET", "/user/[user_id]")(context);
+    const response = await registry.endpoint("GET", "/user/123")(context);
 
-    expect(response).toStrictEqual({ body: "GET user_id" });
+    expect(response).toStrictEqual({ body: "user 123" });
   });
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -134,4 +134,28 @@ describe("a scripted server", () => {
 
     expect(response).toStrictEqual({ body: "user 123" });
   });
+
+  it("handles static routes (v2)", async () => {
+    const registry = new Registry();
+
+    registry.add("/user/profile", {
+      GET() {
+        return { body: "user profile" };
+      },
+    });
+
+    const context = {
+      path: "",
+
+      reduce(foo) {
+        return foo;
+      },
+
+      store: {},
+    };
+
+    const response = await registry.endpoint2("GET", "/user/profile")(context);
+
+    expect(response).toStrictEqual({ body: "user profile" });
+  });
 });

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -68,4 +68,39 @@ describe("a scripted server", () => {
     expect(postA.body).toBe("POST a");
     expect(postB.body).toBe("POST b");
   });
+
+  it("creates a module tree", () => {
+    const registry = new Registry();
+
+    registry.add("/foo", {});
+    registry.add("/bar", {});
+
+    expect(registry.moduleTree).toStrictEqual({
+      foo: {},
+      bar: {},
+    });
+  });
+
+  it.skip("handles dynamic routes", async () => {
+    const registry = new Registry();
+
+    registry.add("/user/[userid]", {
+      GET() {
+        return { body: "GET userid" };
+      },
+    });
+
+    const context = {
+      path: "",
+
+      reduce(foo) {
+        return foo;
+      },
+
+      store: {},
+    };
+    const response = await registry.endpoint("GET", "/user/123")(context);
+
+    expect(response).toBe("GET userid");
+  });
 });

--- a/test/tree-functions.test.js
+++ b/test/tree-functions.test.js
@@ -144,4 +144,35 @@ describe("traces the path to the last matching node", () => {
       }).value
     ).toBe("beta");
   });
+
+  it("when the node is acceptable but intermediate nodes are not", () => {
+    const tree = {
+      children: {
+        alpha: {
+          value: "alpha",
+
+          children: {
+            beta: {
+              value: "beta",
+
+              children: {
+                gamma: {
+                  value: "gamma",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      deepestAcceptableNodeInPath({
+        tree,
+        path: ["alpha", "beta", "gamma"],
+        isAcceptable: (node) => node.value === "gamma",
+        findChild: (node, name) => node.children[name],
+      }).value
+    ).toBe("gamma");
+  });
 });

--- a/test/tree-functions.test.js
+++ b/test/tree-functions.test.js
@@ -1,0 +1,147 @@
+import { deepestAcceptableNodeInPath } from "../src/tree-functions.js";
+
+describe("traces the path to the last matching node", () => {
+  it("when all nodes are acceptable", () => {
+    const tree = {
+      children: {
+        alpha: {
+          value: "alpha",
+
+          children: {
+            beta: {
+              value: "beta",
+
+              children: {
+                gamma: {
+                  value: "gamma",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      deepestAcceptableNodeInPath({
+        tree,
+        path: ["alpha", "beta", "gamma"],
+        isAcceptable: () => true,
+        findChild: (node, name) => node.children[name],
+      }).value
+    ).toBe("gamma");
+
+    expect(
+      deepestAcceptableNodeInPath({
+        tree,
+        path: ["alpha", "beta"],
+        isAcceptable: () => true,
+        findChild: (node, name) => node.children[name],
+      }).value
+    ).toBe("beta");
+  });
+
+  it("when some nodes are not acceptable", () => {
+    const tree = {
+      children: {
+        alpha: {
+          value: "alpha",
+
+          children: {
+            beta: {
+              value: "beta",
+
+              children: {
+                gamma: {
+                  value: "gamma",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      deepestAcceptableNodeInPath({
+        tree,
+        path: ["alpha", "beta", "gamma"],
+        isAcceptable: (node) => node.value !== "gamma",
+        findChild: (node, name) => node.children[name],
+      }).value
+    ).toBe("beta");
+  });
+
+  it("when the path is calculated", () => {
+    const tree = {
+      children: {
+        alpha: {
+          value: "alpha",
+
+          children: {
+            beta: {
+              value: "beta",
+
+              children: {
+                gamma: {
+                  value: "gamma",
+                },
+              },
+            },
+
+            "[dynamic]": {
+              children: {
+                gamma: {
+                  value: "gamma-in-dynamic-path",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      deepestAcceptableNodeInPath({
+        tree,
+        path: ["alpha", "not a match", "gamma"],
+        isAcceptable: () => true,
+
+        findChild: (node, name) =>
+          // eslint-disable-next-line jest/no-conditional-in-test
+          node.children[name] ?? node.children["[dynamic]"],
+      }).value
+    ).toBe("gamma-in-dynamic-path");
+  });
+
+  it("when the path points to a non-existent child", () => {
+    const tree = {
+      children: {
+        alpha: {
+          value: "alpha",
+
+          children: {
+            beta: {
+              value: "beta",
+
+              children: {
+                gamma: {
+                  value: "gamma",
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    expect(
+      deepestAcceptableNodeInPath({
+        tree,
+        path: ["alpha", "beta", "goose"],
+        isAcceptable: () => true,
+        findChild: (node, name) => node.children[name],
+      }).value
+    ).toBe("beta");
+  });
+});


### PR DESCRIPTION
A basic implementation of Next.js-inspired dynamic routes.

If a file or directory's name is wrapped in brackets (e.g. `[user_id].js`) it will be used as a wildcard. The value shows up in the context object in a key called `pathParameters`.

```js
    // /users/[user_id].js 

    GET({ pathParameters }) {
        return { body: `user ${pathParameters.user_id}` };
    }
```

There's a lot wrong with the current implementation. It doesn't handle routes that have multiple dynamic parts (`/org/[org_id]/[user_id].js`). It needs more tests. And the code is a mess. Lots of recursion mixed with a advanced syntax that makes it very hard to follow. 
