### PR TITLE
Install husky and run eslint after commits

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,8 @@
 "use strict";
 
 module.exports = {
+  ignorePatterns: ["/node_modules/", "/coverage/", "/reports/"],
+
   extends: ["hardcore", "hardcore/ts", "hardcore/node"],
 
   parserOptions: {

--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm run lint

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "scripts": {
     "test": "yarn node --experimental-vm-modules $(yarn bin jest)",
     "test:mutants": "stryker run stryker.config.json",
-    "release": "npx changeset publish"
+    "release": "npx changeset publish",
+    "prepare": "husky install",
+    "lint": "eslint ."
   },
   "devDependencies": {
     "@changesets/cli": "2.22.0",
@@ -33,6 +35,7 @@
     "eslint-formatter-github-annotations": "0.1.0",
     "jest": "28.1.1",
     "koa": "2.13.4",
+    "husky": "8.0.1",
     "nodemon": "2.0.16",
     "stryker-cli": "1.0.2",
     "supertest": "6.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,7 +5098,7 @@ human-signals@^3.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
-husky@^8.0.1:
+husky@8.0.1:
   version "8.0.1"
   resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
   integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -5098,6 +5098,11 @@ human-signals@^3.0.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-3.0.1.tgz#c740920859dafa50e5a3222da9d3bf4bb0e5eef5"
   integrity sha512-rQLskxnM/5OCldHo+wNXbpVgDn5A17CUoKX+7Sokwaknlq7CdSnphy0W39GU8dw59XiCXmFXDg4fRuckQRKewQ==
 
+husky@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.1.tgz#511cb3e57de3e3190514ae49ed50f6bc3f50b3e9"
+  integrity sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==
+
 iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Normally ESLint is run as a pre-commit hook.

But having a commit blocked because of lint errors can be annoying sometimes.
Sometimes I'm okay with things being broken temporarily; CI will run ESLint
and prevent the offending code from landing on main.

But then there's a new problem. Code is committed and pushed, and then CI
fails because of a silly lint error. I'm giving the post-commit hook at try
so I can find out immediately if the code I just pushed will break CI.

Let's see how this goes...