### PR TITLE
Add a tools object that will be provided to the request

### DIFF
--- a/.changeset/gentle-kangaroos-switch.md
+++ b/.changeset/gentle-kangaroos-switch.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Add a tools object that will be provided to the request

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -59,6 +59,7 @@ module.exports = {
           {
             ignorePattern: "eslint|it\\(|describe\\(",
             ignoreTemplateLiterals: true,
+            length: 120,
           },
         ],
 

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -59,7 +59,6 @@ module.exports = {
           {
             ignorePattern: "eslint|it\\(|describe\\(",
             ignoreTemplateLiterals: true,
-            length: 120,
           },
         ],
 

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,4 +1,4 @@
-import { Tools } from "./tools";
+import { Tools } from "./tools.js";
 
 export class Dispatcher {
   registry;

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -1,3 +1,5 @@
+import { Tools } from "./tools";
+
 export class Dispatcher {
   registry;
 
@@ -5,12 +7,12 @@ export class Dispatcher {
     this.registry = registry;
   }
 
-  request({ method, path, body, query }) {
+  request({ method, path, headers, body, query }) {
     return this.registry.endpoint(
       method,
       path
     )({
-      // path: parts.slice(remainingParts).join("/"),
+      tools: new Tools({ headers }),
 
       reduce: (reducer) => {
         this.registry.context = reducer(this.registry.context);

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,0 +1,5 @@
+export class Tools {
+  oneOf(array) {
+    return array[Math.floor(Math.random() * array.length)];
+  }
+}

--- a/src/tools.js
+++ b/src/tools.js
@@ -1,5 +1,26 @@
 export class Tools {
+  constructor({ headers = {} } = {}) {
+    this.headers = headers;
+  }
+
   oneOf(array) {
     return array[Math.floor(Math.random() * array.length)];
+  }
+
+  accepts(contentType) {
+    const acceptHeader = this.headers.Accept;
+    if (!acceptHeader) {
+      return true;
+    }
+
+    const acceptTypes = acceptHeader.split(",");
+
+    return acceptTypes.some((acceptType) => {
+      const [type, subtype] = acceptType.split("/");
+      return (
+        (type === "*" || type === contentType.split("/")[0]) &&
+        (subtype === "*" || subtype === contentType.split("/")[1])
+      );
+    });
   }
 }

--- a/src/tools.js
+++ b/src/tools.js
@@ -9,6 +9,7 @@ export class Tools {
 
   accepts(contentType) {
     const acceptHeader = this.headers.Accept;
+
     if (!acceptHeader) {
       return true;
     }
@@ -17,6 +18,7 @@ export class Tools {
 
     return acceptTypes.some((acceptType) => {
       const [type, subtype] = acceptType.split("/");
+
       return (
         (type === "*" || type === contentType.split("/")[0]) &&
         (subtype === "*" || subtype === contentType.split("/")[1])

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -72,6 +72,40 @@ describe("a dispatcher", () => {
     expect(response.body).toBe("Searching for stores near 90210!");
   });
 
+  it("passes a tools object", async () => {
+    const registry = new Registry();
+
+    registry.add("/a", {
+      GET({ query, tools }) {
+        if (tools.accepts("text/html")) {
+          return { contentType: "text/html", body: "<p>Hello!</p>" };
+        }
+        return { contentType: "text/plain", body: "Hello!" };
+      },
+    });
+
+    const dispatcher = new Dispatcher(registry);
+    const htmlResponse = await dispatcher.request({
+      method: "GET",
+      path: "/a",
+      headers: {
+        Accept: "text/html",
+      },
+    });
+
+    expect(htmlResponse.contentType).toBe("text/html");
+
+    const textResponse = await dispatcher.request({
+      method: "GET",
+      path: "/a",
+      headers: {
+        Accept: "text/plain",
+      },
+    });
+
+    expect(textResponse.body).toBe("Hello!");
+  });
+
   it("passes status code in the response", async () => {
     const registry = new Registry();
 

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -76,11 +76,8 @@ describe("a dispatcher", () => {
     const registry = new Registry();
 
     registry.add("/a", {
-      GET({ query, tools }) {
-        if (tools.accepts("text/html")) {
-          return { contentType: "text/html", body: "<p>Hello!</p>" };
-        }
-        return { contentType: "text/plain", body: "Hello!" };
+      GET({ tools }) {
+        return { body: tools.accepts("text/html") };
       },
     });
 
@@ -88,22 +85,24 @@ describe("a dispatcher", () => {
     const htmlResponse = await dispatcher.request({
       method: "GET",
       path: "/a",
+
       headers: {
         Accept: "text/html",
       },
     });
 
-    expect(htmlResponse.contentType).toBe("text/html");
+    expect(htmlResponse.body).toBe(true);
 
     const textResponse = await dispatcher.request({
       method: "GET",
       path: "/a",
+
       headers: {
         Accept: "text/plain",
       },
     });
 
-    expect(textResponse.body).toBe("Hello!");
+    expect(textResponse.body).toBe(false);
   });
 
   it("passes status code in the response", async () => {

--- a/test/tools.test.js
+++ b/test/tools.test.js
@@ -8,26 +8,26 @@ describe("tools", () => {
   });
 
   it.each`
-    contentType    | acceptHeader
-    ${"what/ever"} | ${undefined}
-    ${"text/html"}    | ${"text/html"}
-    ${"text/html"}    | ${"text/*"}
-    ${"application/json"}    | ${"*/json"}
-    ${"text/*"}    | ${"text/*"}
+    contentType           | acceptHeader
+    ${"what/ever"}        | ${undefined}
+    ${"text/html"}        | ${"text/html"}
+    ${"text/html"}        | ${"text/*"}
+    ${"application/json"} | ${"*/json"}
+    ${"text/*"}           | ${"text/*"}
   `(
     "accept('$contentType') returns true when the accept header is $acceptHeader",
     ({ contentType, acceptHeader }) => {
       const tools = new Tools({ headers: { Accept: acceptHeader } });
 
       expect(tools.accepts(contentType)).toBe(true);
-    } 
+    }
   );
 
   it.each`
-    contentType              | acceptHeader
-    ${"application/json"}    | ${"text/*"}
-    ${"text/html"}           | ${"text/plain"}
-    ${"application/json"}    | ${"text/json"}
+    contentType           | acceptHeader
+    ${"application/json"} | ${"text/*"}
+    ${"text/html"}        | ${"text/plain"}
+    ${"application/json"} | ${"text/json"}
   `(
     "accept('$contentType') returns false when the accept header is $acceptHeader",
     ({ contentType, acceptHeader }) => {

--- a/test/tools.test.js
+++ b/test/tools.test.js
@@ -6,4 +6,34 @@ describe("tools", () => {
 
     expect(["A", "B", "C"]).toContain(tools.oneOf(["A", "B", "C"]));
   });
+
+  it.each`
+    contentType    | acceptHeader
+    ${"what/ever"} | ${undefined}
+    ${"text/html"}    | ${"text/html"}
+    ${"text/html"}    | ${"text/*"}
+    ${"application/json"}    | ${"*/json"}
+    ${"text/*"}    | ${"text/*"}
+  `(
+    "accept('$contentType') returns true when the accept header is $acceptHeader",
+    ({ contentType, acceptHeader }) => {
+      const tools = new Tools({ headers: { Accept: acceptHeader } });
+
+      expect(tools.accepts(contentType)).toBe(true);
+    } 
+  );
+
+  it.each`
+    contentType              | acceptHeader
+    ${"application/json"}    | ${"text/*"}
+    ${"text/html"}           | ${"text/plain"}
+    ${"application/json"}    | ${"text/json"}
+  `(
+    "accept('$contentType') returns false when the accept header is $acceptHeader",
+    ({ contentType, acceptHeader }) => {
+      const tools = new Tools({ headers: { Accept: acceptHeader } });
+
+      expect(tools.accepts(contentType)).toBe(false);
+    }
+  );
 });

--- a/test/tools.test.js
+++ b/test/tools.test.js
@@ -1,0 +1,9 @@
+import { Tools } from "../src/tools.js";
+
+describe("tools", () => {
+  it("oneOf()", () => {
+    const tools = new Tools();
+
+    expect(["A", "B", "C"]).toContain(tools.oneOf(["A", "B", "C"]));
+  });
+});


### PR DESCRIPTION
It provides some useful functionality:


- `tools.oneOf(array)` returns a random item from an array (used for selecting a random example from a an OpenAPI schema)
- `tools.accepts(contentType)` identifies whether the request accepts a particular content type

