### PR TITLE
Add basic devcontainer.

### DIFF
--- a/.changeset/blue-mangos-talk.md
+++ b/.changeset/blue-mangos-talk.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+Setup basic devcontainer.

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+RUN su node -c "npm install -g ts-node"

--- a/.devcontainer/base.Dockerfile
+++ b/.devcontainer/base.Dockerfile
@@ -1,0 +1,17 @@
+# [Choice] Node.js version (use -bullseye variants on local arm64/Apple Silicon): 18, 16, 14, 18-bullseye, 16-bullseye, 14-bullseye, 18-buster, 16-buster, 14-buster
+ARG VARIANT=16-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# Install tslint, typescript. eslint is installed by javascript image
+ARG NODE_MODULES="tslint-to-eslint-config typescript"
+COPY library-scripts/meta.env /usr/local/etc/vscode-dev-containers
+RUN su node -c "umask 0002 && npm install -g ${NODE_MODULES}" \
+    && npm cache clean --force > /dev/null 2>&1
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+	"name": "Counterfact",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"VARIANT": "16-bullseye"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"editor.formatOnSave": true,
+				"eslint.format.enable": true,
+				"eslint.packageManager": "yarn",
+				"jest.nodeEnv": {
+					"NODE_OPTIONS": "--experimental-vm-modules"
+				},
+				"[javascript]": {
+					"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+				},
+				"[typescript]": {
+					"editor.defaultFormatter": "dbaeumer.vscode-eslint"
+				}
+			},
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"ms-azuretools.vscode-docker"
+			]
+		}
+	},
+	"postCreateCommand": "yarn install",
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,8 @@
 			},
 			"extensions": [
 				"dbaeumer.vscode-eslint",
-				"ms-azuretools.vscode-docker"
+				"ms-azuretools.vscode-docker",
+				"usernamehw.errorlens"
 			]
 		}
 	},

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
 				"editor.formatOnSave": true,
 				"eslint.format.enable": true,
 				"eslint.packageManager": "yarn",
+				"files.insertFinalNewline": true,
 				"jest.nodeEnv": {
 					"NODE_OPTIONS": "--experimental-vm-modules"
 				},

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "editor.formatOnSave": true,
   "eslint.format.enable": true,
   "eslint.packageManager": "yarn",
+  "files.insertFinalNewline": true,
   "jest.nodeEnv": {
     "NODE_OPTIONS": "--experimental-vm-modules"
   },

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
+  "editor.formatOnSave": true,
+  "eslint.format.enable": true,
+  "eslint.packageManager": "yarn",
   "jest.nodeEnv": {
     "NODE_OPTIONS": "--experimental-vm-modules"
+  },
+  "[javascript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   }
 }

--- a/README.md
+++ b/README.md
@@ -249,3 +249,23 @@ export async function DELETE() {
 ### Coming soon
 
 Headers, content-type, etc. are not supported yet but coming soon. Hopefully by now you can guess what those APIs are going to look like.
+
+-----
+
+## Development Setup
+
+Looking to get involved? You can begin by cloning the project and using one of the following setup options.
+
+### Installation (devcontainer)
+
+> **BETA**: We are working through using a devcontainer for development. If you have [Docker](https://docker.com) on your machine and would like to give it a go and give us some feedback, please clone the repo, and then follow the instructions on the following page in place of the Installation instructions below.
+>
+> - [Guide: Using a devcontainer](https://github.com/WH-HC-Dev/front-end/wiki/Guide:-Using-a-devcontainer)
+
+### Installation (Original Method)
+
+Installation will set up Git hooks and install all of the Node packages. If you're only working on Mobile code this isn't strictly necessary.
+
+1. Make sure you have [Node 16](https://nodejs.org/en/) installed.
+2. Install yarn by running `npm install -g yarn`.
+3. Install the dependencies by running `yarn install`.

--- a/README.md
+++ b/README.md
@@ -260,11 +260,11 @@ Looking to get involved? You can begin by cloning the project and using one of t
 
 > **BETA**: We are working through using a devcontainer for development. If you have [Docker](https://docker.com) on your machine and would like to give it a go and give us some feedback, please clone the repo, and then follow the instructions on the following page in place of the Installation instructions below.
 >
-> - [Guide: Using a devcontainer](https://github.com/WH-HC-Dev/front-end/wiki/Guide:-Using-a-devcontainer)
+> - [Quick start: Open an existing folder in a container.](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container)
 
 ### Installation (Original Method)
 
-Installation will set up Git hooks and install all of the Node packages. If you're only working on Mobile code this isn't strictly necessary.
+Installation will set up Git hooks and install all of the Node packages.
 
 1. Make sure you have [Node 16](https://nodejs.org/en/) installed.
 2. Install yarn by running `npm install -g yarn`.


### PR DESCRIPTION
Code to add a basic devcontainer.

I left the configuration pretty light. I've also left the `.vscode` directory in place for those that don't want (or can't) use the container. We'll need to keep them in sync.