### PR TITLE
Add headers concept to Counterfact, add example user route

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -12,4 +12,6 @@ Under `./routes` you will find a few endpoints definitions:
 
 `count.js` defines `/count` and reports how many times you've visited the other URLs.
 
+`user.js` defines `/user` and sends back a decoded JWT. The token is read from the headers and decoded in the response body.
+
 Try adding more routes. You should be able to see the updates without restarting the server.

--- a/demo/index.js
+++ b/demo/index.js
@@ -21,3 +21,4 @@ console.log(`http://localhost:${PORT}/hello/friends`);
 console.log(`http://localhost:${PORT}/hello/kitty`);
 console.log(`http://localhost:${PORT}/hello/world?greeting=Hi`);
 console.log(`http://localhost:${PORT}/count`);
+console.log(`http://localhost:${PORT}/user`);

--- a/demo/routes/user.js
+++ b/demo/routes/user.js
@@ -1,0 +1,32 @@
+import { decode } from "jsonwebtoken";
+
+const mockJWT =
+  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+const authorizationHeader = {
+  authorization: `Bearer ${mockJWT}`,
+};
+
+export function GET({ path, context, headers = authorizationHeader }) {
+  context.visits ??= {};
+
+  context.visits[path.name] ??= 0;
+
+  context.visits[path.name] += 1;
+
+  if (!headers.authorization) {
+    return {
+      status: 401,
+    };
+  }
+
+  const { authorization } = headers;
+
+  const [, token] = authorization.split(" ");
+
+  const result = decode(token);
+
+  return {
+    body: result,
+  };
+}

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
     "@types/json-schema": "^7.0.11",
     "chokidar": "^3.5.3",
     "js-yaml": "^4.1.0",
-    "prettier": "^2.7.1",
-    "json-schema-faker": "^0.5.0-rcv.44"
-
+    "json-schema-faker": "^0.5.0-rcv.44",
+    "jsonwebtoken": "^8.5.1",
+    "prettier": "^2.7.1"
   }
 }

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -21,6 +21,7 @@ export class Dispatcher {
       context: this.registry.context,
       body,
       query,
+      headers,
     });
   }
 }

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -50,27 +50,31 @@ describe("a dispatcher", () => {
 
   it("passes the request headers", async () => {
     const registry = new Registry();
-    const mockedJWT =
-      // eslint-disable-next-line max-len
-      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+    const mockedJWT = "test token";
 
     registry.add("/a", {
       GET({ headers }) {
         return {
-          headers: `User token from the header: ${headers}`,
+          headers,
         };
       },
     });
 
     const dispatcher = new Dispatcher(registry);
+
+    const authHeader = {
+      Authorization: `Bearer: ${mockedJWT}`,
+      "Cache-Control": "max-age=0",
+    };
+
     const response = await dispatcher.request({
       method: "GET",
       path: "/a",
 
-      headers: mockedJWT,
+      headers: authHeader,
     });
 
-    expect(response.headers).toBe(`User token from the header: ${mockedJWT}`);
+    expect(response.headers).toBe(authHeader);
   });
 
   it("passes the query params", async () => {

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -48,6 +48,31 @@ describe("a dispatcher", () => {
     expect(response.body).toBe("Hello Catherine of Aragon!");
   });
 
+  it("passes the request headers", async () => {
+    const registry = new Registry();
+    const mockedJWT =
+      // eslint-disable-next-line max-len
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+
+    registry.add("/a", {
+      GET({ headers }) {
+        return {
+          headers: `User token from the header: ${headers}`,
+        };
+      },
+    });
+
+    const dispatcher = new Dispatcher(registry);
+    const response = await dispatcher.request({
+      method: "GET",
+      path: "/a",
+
+      headers: mockedJWT,
+    });
+
+    expect(response.headers).toBe(`User token from the header: ${mockedJWT}`);
+  });
+
   it("passes the query params", async () => {
     const registry = new Registry();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2961,6 +2961,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -3750,6 +3755,13 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
+
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
 
 ee-first@1.1.1:
   version "1.1.1"
@@ -6200,6 +6212,22 @@ jsonpath-plus@^5.1.0:
   resolved "https://registry.yarnpkg.com/jsonpath-plus/-/jsonpath-plus-5.1.0.tgz#2fc4b2e461950626c98525425a3a3518b85af6c3"
   integrity sha512-890w2Pjtj0iswAxalRlt2kHthi6HKrXEfZcn+ZNZptv7F3rUGIeDuZo+C+h4vXBHLEsVjJrHeCm35nYeZLzSBQ==
 
+jsonwebtoken@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
+  integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^5.6.0"
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.2.1, jsx-ast-utils@^3.3.0, jsx-ast-utils@^3.3.1:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.2.tgz#afe5efe4332cd3515c065072bd4d6b0aa22152bd"
@@ -6227,6 +6255,23 @@ just-kebab-case@^3.0.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/just-kebab-case/-/just-kebab-case-3.1.1.tgz#e88a13347cd12830b233d9f8c00d41792781581a"
   integrity sha512-/2ORPfWcyLyGFhHmzVVthL84yD2oWl9dUvP1/yO+DcZAsDujNN+FwG5jSdZ+MlOIaxGr4cxmwbo23omD2lAXgA==
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
 
 keygrip@~1.1.0:
   version "1.1.0"
@@ -6400,10 +6445,45 @@ lodash.groupby@~4.6.0:
   resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
   integrity sha512-5dcWxm23+VAoz+awKmBaiBvzox8+RqMgFhi7UvX9DHZr2HdxHXM/Wrf8cfKpsW37RNrvtPn6hSwNqurSILbmJw==
 
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 lodash.startcase@^4.4.0:
   version "4.4.0"
@@ -8429,7 +8509,7 @@ semver-diff@^3.1.1:
   dependencies:
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.7.1:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.6.0, semver@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==


### PR DESCRIPTION
This is a very basic implementation of headers in Counterfact. If we go with this route, you can send headers in any route, and get them returned to you on the response. 

I added an example implementation under `demo/user.js` to decode a JWT sent in an authorization header. 

There wasnt much to actually test here since the Counterfact side is really simple. 

closes #21 