### PR TITLE
performance tuning for automatic formatting in VSCode via ESLint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,35 +1,47 @@
 {
-	"name": "Counterfact",
-	"build": {
-		"dockerfile": "Dockerfile",
-		"args": {
-			"VARIANT": "16-bullseye"
-		}
-	},
-	"customizations": {
-		"vscode": {
-			"settings": {
-				"editor.formatOnSave": true,
-				"eslint.format.enable": true,
-				"eslint.packageManager": "yarn",
-				"files.insertFinalNewline": true,
-				"jest.nodeEnv": {
-					"NODE_OPTIONS": "--experimental-vm-modules"
-				},
-				"[javascript]": {
-					"editor.defaultFormatter": "dbaeumer.vscode-eslint"
-				},
-				"[typescript]": {
-					"editor.defaultFormatter": "dbaeumer.vscode-eslint"
-				}
-			},
-			"extensions": [
-				"dbaeumer.vscode-eslint",
-				"ms-azuretools.vscode-docker",
-				"usernamehw.errorlens"
-			]
-		}
-	},
-	"postCreateCommand": "yarn install",
-	"remoteUser": "node"
+  "name": "Counterfact",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "args": {
+      "VARIANT": "16-bullseye"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.formatOnSave": true,
+        "eslint.format.enable": true,
+        "eslint.packageManager": "yarn",
+        "eslint.codeActionsOnSave.mode": "problems",
+        "eslint.codeActionsOnSave.rules": [
+          "!import/namespace",
+          "!etc/no-deprecated",
+          "!import/no-cycle",
+          "!no-explicit-type-exports/no-explicit-type-exports",
+          "!import/no-deprecated",
+          "!import/no-self-import",
+          "!import/default",
+          "!import/no-named-as-default",
+          "*"
+        ],
+        "files.insertFinalNewline": true,
+        "jest.nodeEnv": {
+          "NODE_OPTIONS": "--experimental-vm-modules"
+        },
+        "[javascript]": {
+          "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+        },
+        "[typescript]": {
+          "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+        }
+      },
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "ms-azuretools.vscode-docker",
+        "usernamehw.errorlens"
+      ]
+    }
+  },
+  "postCreateCommand": "yarn install",
+  "remoteUser": "node"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,18 @@
   "editor.formatOnSave": true,
   "eslint.format.enable": true,
   "eslint.packageManager": "yarn",
+  "eslint.codeActionsOnSave.mode": "problems",
+  "eslint.codeActionsOnSave.rules": [
+    "!import/namespace",
+    "!etc/no-deprecated",
+    "!import/no-cycle",
+    "!no-explicit-type-exports/no-explicit-type-exports",
+    "!import/no-deprecated",
+    "!import/no-self-import",
+    "!import/default",
+    "!import/no-named-as-default",
+    "*"
+  ],
   "files.insertFinalNewline": true,
   "jest.nodeEnv": {
     "NODE_OPTIONS": "--experimental-vm-modules"


### PR DESCRIPTION
Some of the ESLint rules depend on the filesystem and can be very slow. If those rules are not fixable, there's no point in running them when formatting on save. 

I'm not 100% sure this is necessary but I _think_ it helped fix really slow saves in my environment. 