### PR TITLE
128 simple api for simple response

### DIFF
--- a/.changeset/purple-cups-greet.md
+++ b/.changeset/purple-cups-greet.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+a function can now return "hello world" as shorthand for `{status: 200, contentType: "text/plain", body: "hello world"}`

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -14,10 +14,6 @@ export class Dispatcher {
     )({
       tools: new Tools({ headers }),
 
-      reduce: (reducer) => {
-        this.registry.context = reducer(this.registry.context);
-      },
-
       context: this.registry.context,
       body,
       query,

--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -8,16 +8,31 @@ export class Dispatcher {
   }
 
   request({ method, path, headers, body, query }) {
-    return this.registry.endpoint(
-      method,
-      path
-    )({
-      tools: new Tools({ headers }),
+    return this.wrapResponse(
+      this.registry.endpoint(
+        method,
+        path
+      )({
+        tools: new Tools({ headers }),
 
-      context: this.registry.context,
-      body,
-      query,
-      headers,
-    });
+        context: this.registry.context,
+        body,
+        query,
+        headers,
+      })
+    );
+  }
+
+  wrapResponse(response) {
+    if (typeof response === "string") {
+      return {
+        status: 200,
+        headers: {},
+        contentType: "text/plain",
+        body: response,
+      };
+    }
+
+    return response;
   }
 }

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -155,40 +155,6 @@ describe("a dispatcher", () => {
     expect(response.status).toBe(201);
   });
 
-  it("passes a reducer function that can be used to read / update the store", async () => {
-    const registry = new Registry({ value: 0 });
-
-    registry.add("/increment/{value}", {
-      GET({ reduce, path }) {
-        const amountToIncrement = Number.parseInt(path.value, 10);
-
-        reduce((context) => ({
-          value: context.value + amountToIncrement,
-        }));
-
-        return { body: "incremented" };
-      },
-    });
-
-    const dispatcher = new Dispatcher(registry);
-
-    await dispatcher.request({
-      method: "GET",
-      path: "/increment/1",
-      body: "",
-    });
-
-    expect(registry.context.value).toBe(1);
-
-    await dispatcher.request({
-      method: "GET",
-      path: "/increment/2",
-      body: "",
-    });
-
-    expect(registry.context.value).toBe(3);
-  });
-
   it("allows the store to be mutated directly", async () => {
     const registry = new Registry({ value: 0 });
 

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -155,7 +155,7 @@ describe("a dispatcher", () => {
     expect(response.status).toBe(201);
   });
 
-  it("allows the store to be mutated directly", async () => {
+  it("allows the context object to be mutated directly", async () => {
     const registry = new Registry({ value: 0 });
 
     registry.add("/increment/{value}", {

--- a/test/dispatcher.test.js
+++ b/test/dispatcher.test.js
@@ -17,10 +17,32 @@ describe("a dispatcher", () => {
     const response = await dispatcher.request({
       method: "GET",
       path: "/hello",
-      body: "",
     });
 
     expect(response.body).toBe("hello");
+  });
+
+  it("converts a string return value to a full response object with content-type text/plain", async () => {
+    const registry = new Registry();
+
+    registry.add("/hello", {
+      GET() {
+        return "hello";
+      },
+    });
+
+    const dispatcher = new Dispatcher(registry);
+    const response = await dispatcher.request({
+      method: "GET",
+      path: "/hello",
+    });
+
+    expect(response).toStrictEqual({
+      status: 200,
+      headers: {},
+      contentType: "text/plain",
+      body: "hello",
+    });
   });
 
   it("passes the request body", async () => {


### PR DESCRIPTION
- remove the reducer function, an early idea that was never documented
- clarification in test description
- support 'hello world' scenario returning just a string instead of a response object

