### PR TITLE
change Jest coverageProvider to "v8"

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -4,6 +4,7 @@
   "collectCoverage": true,
 
   "collectCoverageFrom": ["src/**/*.{js,jsx,ts,tsx}", "!**/node_modules/**"],
+  "coverageProvider": "v8",
 
   "coverageThreshold": {
     "global": {


### PR DESCRIPTION
Babel wasn't working. While the V8 provider is still considered experimental, it seems to be where things are going, and it works.

https://jestjs.io/blog/2020/01/21/jest-25#v8-code-coverage
