### PR TITLE
response.random() 

### DIFF
--- a/.changeset/plenty-peaches-sneeze.md
+++ b/.changeset/plenty-peaches-sneeze.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+Counterfact is now able to read an OpenAPI document and use it to generate a random response.

--- a/demo/openapi.yaml
+++ b/demo/openapi.yaml
@@ -1,0 +1,57 @@
+openapi: 3.0.3
+info:
+  version: 1.0.0 
+  title: Sample API
+  description: A sample API to illustrate OpenAPI concepts
+paths:
+  /count:
+    get:
+      description: outputs the number of time each URL was visited
+      responses:
+        default:
+          description: Successful response
+          content:
+            application/json:
+              schema: 
+                type: 
+                  string
+              examples:
+                no visits:
+                  value: You have not visited anyone yet
+  /hello/kitty:
+    get:
+      description: HTML with a hello kitty image
+      responses:
+        default:
+          description: Successful response
+          content:
+            application/json:
+              schema: 
+                type: 
+                  string
+              examples:
+                hello kitty:
+                  value: >-
+                    <img
+                    src="https://upload.wikimedia.org/wikipedia/en/0/05/Hello_kitty_character_portrait.png">
+  /hello/{name}:
+    get:
+      parameters:
+        - in: path
+          name: name
+          required: true
+          schema:
+            type: string
+          description: says hello to the name
+      description: says hello to someone
+      responses:
+        default:
+          description: Successful response
+          content:
+            application/json:
+              schema: 
+                type: 
+                  string
+              examples:
+                hello-world:
+                  value: Hello, world

--- a/src/counterfact.js
+++ b/src/counterfact.js
@@ -1,11 +1,31 @@
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+
+import yaml from "js-yaml";
+
 import { Registry } from "./registry.js";
 import { Dispatcher } from "./dispatcher.js";
 import { koaMiddleware } from "./koa-middleware.js";
 import { ModuleLoader } from "./module-loader.js";
 
-export async function counterfact(basePath, context = {}) {
+async function loadOpenApiDocument(source) {
+  try {
+    return yaml.load(await fs.readFile(source, "utf8"));
+  } catch {
+    return undefined;
+  }
+}
+
+export async function counterfact(
+  basePath,
+  context = {},
+  openApiPath = nodePath.join(basePath, "../openapi.yaml")
+) {
+  const openApiDocument = await loadOpenApiDocument(openApiPath);
+
   const registry = new Registry(context);
-  const dispatcher = new Dispatcher(registry);
+
+  const dispatcher = new Dispatcher(registry, openApiDocument);
   const moduleLoader = new ModuleLoader(basePath, registry);
 
   await moduleLoader.load();

--- a/src/registry.js
+++ b/src/registry.js
@@ -86,6 +86,11 @@ export class Registry {
       });
     }
 
-    return ({ ...context }) => lambda({ ...context, path: handler.path });
+    return ({ ...context }) =>
+      lambda({
+        ...context,
+        path: handler.path,
+        matchedPath: handler.matchedPath ?? "none",
+      });
   }
 }

--- a/test/lib/with-temporary-files.js
+++ b/test/lib/with-temporary-files.js
@@ -68,8 +68,8 @@ export async function withTemporaryFiles(files, ...callbacks) {
       });
     }
   } finally {
-    // await fs.rm(temporaryDirectory, {
-    //   recursive: true,
-    // });
+    await fs.rm(temporaryDirectory, {
+      recursive: true,
+    });
   }
 }

--- a/test/lib/with-temporary-files.js
+++ b/test/lib/with-temporary-files.js
@@ -68,8 +68,8 @@ export async function withTemporaryFiles(files, ...callbacks) {
       });
     }
   } finally {
-    await fs.rm(temporaryDirectory, {
-      recursive: true,
-    });
+    // await fs.rm(temporaryDirectory, {
+    //   recursive: true,
+    // });
   }
 }

--- a/test/response-builder.test.js
+++ b/test/response-builder.test.js
@@ -45,4 +45,85 @@ describe("a response builder", () => {
       "x-two": 2,
     });
   });
+
+  describe("builds a random response based on an Open API operation object", () => {
+    const operation = {
+      responses: {
+        200: {
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+
+                properties: {
+                  value: {
+                    type: "string",
+                    required: true,
+                    examples: ["hello"],
+                  },
+                },
+
+                additionalProperties: false,
+              },
+            },
+
+            "text/plain": {
+              schema: {
+                type: "string",
+                examples: ["hello"],
+              },
+            },
+          },
+        },
+
+        default: {
+          content: {
+            "text/plain": {
+              schema: {
+                type: "string",
+                examples: ["an error occurred"],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    it("using the status code", () => {
+      const response = createResponseBuilder(operation)[200].random();
+
+      expect(response.status).toBe(200);
+      expect(response.content).toStrictEqual([
+        { type: "application/json", body: { value: "hello" } },
+        { type: "text/plain", body: "hello" },
+      ]);
+    });
+
+    it("falls back to 'default' when status code is not listed explicitly", () => {
+      const response = createResponseBuilder(operation)[403].random();
+
+      expect(response.status).toBe(403);
+      expect(response.content).toStrictEqual([
+        { type: "text/plain", body: "an error occurred" },
+      ]);
+    });
+
+    it("returns 500 if it doesn't know what to do with the status code", () => {
+      const operationWithoutDefault = { ...operation };
+
+      delete operationWithoutDefault.responses.default;
+
+      const response = createResponseBuilder(
+        operationWithoutDefault
+      )[403].random();
+
+      expect(response.status).toBe(500);
+      expect(response.content).toStrictEqual([
+        {
+          type: "text/plain",
+          body: "The Open API document does not specify a response for status code 403",
+        },
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
Counterfact is now able to read an OpenAPI document and use it to generate a random response.

```js
export function GET ({response}) {
   return response[200].random();
}
```

