### PR TITLE
counterfact depends on counterfact

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,6 +42,7 @@ module.exports = {
     "/reports/",
     "/demo-ts",
     "/templates/",
+    "/out/",
   ],
 
   extends: ["hardcore", "hardcore/ts", "hardcore/node"],

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@hapi/accept": "^6.0.0",
     "@types/json-schema": "^7.0.11",
     "chokidar": "^3.5.3",
+    "counterfact": "./",
     "fs-extra": "^10.1.0",
     "js-yaml": "^4.1.0",
     "json-schema-faker": "^0.5.0-rcv.44",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3425,6 +3425,23 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
+counterfact@./:
+  version "0.7.0"
+  dependencies:
+    "@hapi/accept" "^6.0.0"
+    "@types/json-schema" "^7.0.11"
+    chokidar "^3.5.3"
+    counterfact "./"
+    fs-extra "^10.1.0"
+    js-yaml "^4.1.0"
+    json-schema-faker "^0.5.0-rcv.44"
+    json-schema-ref-parser "^9.0.9"
+    jsonwebtoken "^8.5.1"
+    koa "^2.13.4"
+    koa-bodyparser "^4.3.0"
+    prettier "^2.7.1"
+    typescript "^4.8.2"
+
 crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"


### PR DESCRIPTION
These changes are only intended to make it easier for me to test / bootstrap by generating code and putting in the `./out` directory instead of importing Counterfact from another project.

- make Counterfact a depenency of itself
- tell ESLint to ignore the out directory
