### PR TITLE
saturday refactoring

### DIFF
--- a/src/typescript-generator/generate.js
+++ b/src/typescript-generator/generate.js
@@ -11,8 +11,8 @@ export async function generate(
 
   const requirement = await specification.requirementAt(`${source}#/paths`);
 
-  requirement.forEach(([key, pathDefinition]) => {
-    pathDefinition.forEach(([, operation]) => {
+  requirement.forEach((pathDefinition, key) => {
+    pathDefinition.forEach((operation) => {
       repository.get(`paths${key}.ts`).export(new OperationCoder(operation));
     });
   });

--- a/src/typescript-generator/operation-coder.js
+++ b/src/typescript-generator/operation-coder.js
@@ -16,8 +16,10 @@ export class OperationCoder extends Coder {
   write() {
     const responses = this.requirement.get("responses");
 
-    const [firstStatusCode] = responses.map(([statusCode]) => statusCode);
-    const [firstResponse] = responses.map(([, response]) => response.data);
+    const [firstStatusCode] = responses.map(
+      (response, statusCode) => statusCode
+    );
+    const [firstResponse] = responses.map((response) => response.data);
 
     if (!("content" in firstResponse)) {
       return "() => { /* no response content specified in the OpenAPI document */ }";

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -29,7 +29,7 @@ export class OperationTypeCoder extends Coder {
         }
 
         return response.get("content").map(
-          ([contentType, content]) => `{  
+          (content, contentType) => `{  
             status: ${status}, 
             contentType?: "${contentType}",
             body?: ${new SchemaTypeCoder(content.get("schema")).write(script)}

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -16,7 +16,7 @@ export class OperationTypeCoder extends Coder {
   responseTypes(script) {
     return this.requirement
       .get("responses")
-      .flatMap(([responseCode, response]) => {
+      .flatMap((response, responseCode) => {
         const status =
           responseCode === "default"
             ? "number | undefined"

--- a/src/typescript-generator/print-object-from-entries.js
+++ b/src/typescript-generator/print-object-from-entries.js
@@ -1,0 +1,5 @@
+export function printObjectFromEntries(entries) {
+  return `{\n${entries
+    .map(([key, value]) => `"${key}": ${value}`)
+    .join(",\n")}\n}`;
+}

--- a/src/typescript-generator/printers.js
+++ b/src/typescript-generator/printers.js
@@ -1,0 +1,15 @@
+export function printObjectWithoutQuotes(entries) {
+  return `{\n${entries
+    .map(([key, value]) => `${key}: ${value}`)
+    .join(",\n")}\n}`;
+}
+
+export function printObject(entries) {
+  return `{\n${entries
+    .map(([key, value]) => `"${key}": ${value}`)
+    .join(",\n")}\n}`;
+}
+
+export function printArray(items) {
+  return `[\n${items.join(",\n")}\n]`;
+}

--- a/src/typescript-generator/requirement.js
+++ b/src/typescript-generator/requirement.js
@@ -77,8 +77,12 @@ export class Requirement {
   }
 
   flatMap(callback) {
-    // eslint-disable-next-line unicorn/prefer-array-flat-map
-    return this.map(callback).flat();
+    const result = [];
+
+    // eslint-disable-next-line array-callback-return
+    this.forEach(([key, value]) => result.push(callback(value, key)));
+
+    return result.flat();
   }
 
   escapeJsonPointer(string) {

--- a/src/typescript-generator/requirement.js
+++ b/src/typescript-generator/requirement.js
@@ -71,7 +71,7 @@ export class Requirement {
     const result = [];
 
     // eslint-disable-next-line array-callback-return
-    this.forEach((entry) => result.push(callback(entry)));
+    this.forEach(([key, value]) => result.push(callback(value, key)));
 
     return result;
   }

--- a/src/typescript-generator/requirement.js
+++ b/src/typescript-generator/requirement.js
@@ -63,7 +63,7 @@ export class Requirement {
 
   forEach(callback) {
     Object.keys(this.data).forEach((key) => {
-      callback([key, this.select(this.escapeJsonPointer(key))]);
+      callback(this.select(this.escapeJsonPointer(key)), key);
     });
   }
 
@@ -71,7 +71,7 @@ export class Requirement {
     const result = [];
 
     // eslint-disable-next-line array-callback-return
-    this.forEach(([key, value]) => result.push(callback(value, key)));
+    this.forEach((value, key) => result.push(callback(value, key)));
 
     return result;
   }

--- a/src/typescript-generator/requirement.js
+++ b/src/typescript-generator/requirement.js
@@ -77,12 +77,8 @@ export class Requirement {
   }
 
   flatMap(callback) {
-    const result = [];
-
-    // eslint-disable-next-line array-callback-return
-    this.forEach(([key, value]) => result.push(callback(value, key)));
-
-    return result.flat();
+    // eslint-disable-next-line unicorn/prefer-array-flat-map
+    return this.map(callback).flat();
   }
 
   escapeJsonPointer(string) {

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -31,7 +31,7 @@ export class ResponseTypeCoder extends Coder {
       return "{}";
     }
 
-    const keyValuePairs = response.get("content").map(
+    const properties = response.get("content").map(
       (content, mediaType) =>
         `"${mediaType}": { 
           schema:  ${new SchemaTypeCoder(content.get("schema")).write(script)}
@@ -39,7 +39,7 @@ export class ResponseTypeCoder extends Coder {
     );
 
     return `{
-      ${keyValuePairs.join(",\n")}
+      ${properties.join(",\n")}
     }`;
   }
 

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -4,19 +4,23 @@ import { Coder } from "./coder.js";
 import { SchemaTypeCoder } from "./schema-type-coder.js";
 
 export class ResponseTypeCoder extends Coder {
-  normalizeStatusCode(statusCode, responses) {
-    const definedStatusCodes = Object.keys(responses).filter(
+  typeForDefaultStatusCode(listedStatusCodes) {
+    const definedStatusCodes = listedStatusCodes.filter(
       (key) => key !== "default"
     );
 
-    if (statusCode === "default") {
-      if (definedStatusCodes.length === 0) {
-        return "[statusCode in HttpStatusCode]";
-      }
+    if (definedStatusCodes.length === 0) {
+      return "[statusCode in HttpStatusCode]";
+    }
 
-      return `[statusCode in Exclude<HttpStatusCode, ${definedStatusCodes.join(
-        " | "
-      )}>]`;
+    return `[statusCode in Exclude<HttpStatusCode, ${definedStatusCodes.join(
+      " | "
+    )}>]`;
+  }
+
+  normalizeStatusCode(statusCode, responses) {
+    if (statusCode === "default") {
+      return this.typeForDefaultStatusCode(Object.keys(responses));
     }
 
     return statusCode;

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -46,12 +46,18 @@ export class ResponseTypeCoder extends Coder {
   buildHeaders(script, responseCode) {
     const response = this.requirement.get(responseCode);
 
-    const properties = Object.keys(response.data.headers ?? {}).map(
-      (name) =>
-        `"${name}": { schema: ${new SchemaTypeCoder(
-          response.get("headers").get(name).get("schema")
-        ).write(script)}}`
-    );
+    if (!response.has("headers")) {
+      return "{}";
+    }
+
+    const properties = response
+      .get("headers")
+      .map(
+        (value, name) =>
+          `"${name}": { schema: ${new SchemaTypeCoder(
+            value.get("schema")
+          ).write(script)}}`
+      );
 
     return `{${properties.join(";")}}`;
   }

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -3,6 +3,12 @@ import nodePath from "node:path";
 import { Coder } from "./coder.js";
 import { SchemaTypeCoder } from "./schema-type-coder.js";
 
+function printObjectFromEntries(entries) {
+  return `{\n${entries
+    .map(([key, value]) => `"${key}": ${value}`)
+    .join(",\n")}\n}`;
+}
+
 export class ResponseTypeCoder extends Coder {
   typeForDefaultStatusCode(listedStatusCodes) {
     const definedStatusCodes = listedStatusCodes.filter(
@@ -31,16 +37,14 @@ export class ResponseTypeCoder extends Coder {
       return "{}";
     }
 
-    const properties = response.get("content").map(
-      (content, mediaType) =>
-        `"${mediaType}": { 
+    const entries = response.get("content").map((content, mediaType) => [
+      mediaType,
+      `{ 
           schema:  ${new SchemaTypeCoder(content.get("schema")).write(script)}
-        }`
-    );
+       }`,
+    ]);
 
-    return `{
-      ${properties.join(",\n")}
-    }`;
+    return printObjectFromEntries(entries);
   }
 
   buildHeaders(script, responseCode) {

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -54,16 +54,14 @@ export class ResponseTypeCoder extends Coder {
       return "{}";
     }
 
-    const properties = response
+    const entries = response
       .get("headers")
-      .map(
-        (value, name) =>
-          `"${name}": { schema: ${new SchemaTypeCoder(
-            value.get("schema")
-          ).write(script)}}`
-      );
+      .map((value, name) => [
+        name,
+        `{ schema: ${new SchemaTypeCoder(value.get("schema")).write(script)}}`,
+      ]);
 
-    return `{${properties.join(";")}}`;
+    return printObjectFromEntries(entries);
   }
 
   buildResponseObjectType(script) {

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -24,9 +24,9 @@ export class ResponseTypeCoder extends Coder {
     )}>]`;
   }
 
-  normalizeStatusCode(statusCode, responses) {
+  normalizeStatusCode(statusCode) {
     if (statusCode === "default") {
-      return this.typeForDefaultStatusCode(Object.keys(responses));
+      return this.typeForDefaultStatusCode(Object.keys(this.requirement.data));
     }
 
     return statusCode;
@@ -47,9 +47,7 @@ export class ResponseTypeCoder extends Coder {
     return printObjectFromEntries(entries);
   }
 
-  buildHeaders(script, responseCode) {
-    const response = this.requirement.get(responseCode);
-
+  buildHeaders(script, response) {
     if (!response.has("headers")) {
       return "{}";
     }
@@ -65,16 +63,13 @@ export class ResponseTypeCoder extends Coder {
   }
 
   buildResponseObjectType(script) {
-    const responses = this.requirement.data;
-
     return `{
       ${this.requirement
         .map(
           (response, responseCode) => `${this.normalizeStatusCode(
-            responseCode,
-            responses
+            responseCode
           )}: {
-          headers: ${this.buildHeaders(script, responseCode)};
+          headers: ${this.buildHeaders(script, response)};
           content: ${this.buildContentObjectType(script, response)};
         }`
         )

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -2,12 +2,7 @@ import nodePath from "node:path";
 
 import { Coder } from "./coder.js";
 import { SchemaTypeCoder } from "./schema-type-coder.js";
-
-function printObjectFromEntries(entries) {
-  return `{\n${entries
-    .map(([key, value]) => `"${key}": ${value}`)
-    .join(",\n")}\n}`;
-}
+import { printObject, printObjectWithoutQuotes } from "./printers.js";
 
 export class ResponseTypeCoder extends Coder {
   typeForDefaultStatusCode(listedStatusCodes) {
@@ -37,44 +32,49 @@ export class ResponseTypeCoder extends Coder {
       return "{}";
     }
 
-    const entries = response.get("content").map((content, mediaType) => [
+    return response.get("content").map((content, mediaType) => [
       mediaType,
       `{ 
           schema:  ${new SchemaTypeCoder(content.get("schema")).write(script)}
        }`,
     ]);
-
-    return printObjectFromEntries(entries);
   }
 
-  buildHeaders(script, response) {
-    if (!response.has("headers")) {
+  printContentObjectType(script, response) {
+    if (!response.has("content")) {
       return "{}";
     }
 
-    const entries = response
+    return printObject(this.buildContentObjectType(script, response));
+  }
+
+  buildHeaders(script, response) {
+    return response
       .get("headers")
       .map((value, name) => [
         name,
         `{ schema: ${new SchemaTypeCoder(value.get("schema")).write(script)}}`,
       ]);
+  }
 
-    return printObjectFromEntries(entries);
+  printHeaders(script, response) {
+    if (!response.has("headers")) {
+      return "{}";
+    }
+
+    return printObject(this.buildHeaders(script, response));
   }
 
   buildResponseObjectType(script) {
-    return `{
-      ${this.requirement
-        .map(
-          (response, responseCode) => `${this.normalizeStatusCode(
-            responseCode
-          )}: {
-          headers: ${this.buildHeaders(script, response)};
-          content: ${this.buildContentObjectType(script, response)};
-        }`
-        )
-        .join(",")}
-      }`;
+    return printObjectWithoutQuotes(
+      this.requirement.map((response, responseCode) => [
+        this.normalizeStatusCode(responseCode),
+        `{
+          headers: ${this.printHeaders(script, response)};
+          content: ${this.printContentObjectType(script, response)};
+        }`,
+      ])
+    );
   }
 
   write(script) {

--- a/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
+++ b/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
@@ -55,13 +55,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },405: {
           headers: {};
           content: {};
@@ -91,13 +91,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -324,13 +324,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },405: {
           headers: {};
           content: {};
@@ -360,13 +360,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -597,13 +597,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },405: {
           headers: {};
           content: {};
@@ -633,13 +633,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -884,13 +884,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Array<Pet>
-        },
+       },
 \\"application/json\\": { 
           schema:  Array<Pet>
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -1081,13 +1081,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Array<Pet>
-        },
+       },
 \\"application/json\\": { 
           schema:  Array<Pet>
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -1294,13 +1294,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Array<Pet>
-        },
+       },
 \\"application/json\\": { 
           schema:  Array<Pet>
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -1491,13 +1491,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Array<Pet>
-        },
+       },
 \\"application/json\\": { 
           schema:  Array<Pet>
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -1732,13 +1732,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -2034,13 +2034,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -2336,13 +2336,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -2642,13 +2642,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Pet
-        },
+       },
 \\"application/json\\": { 
           schema:  Pet
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -2960,10 +2960,10 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  ApiResponse
-        }
-    };
+       }
+};
         }
       }> }) => {  
             status: 200, 
@@ -3082,10 +3082,10 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  ApiResponse
-        }
-    };
+       }
+};
         }
       }> }) => {  
             status: 200, 
@@ -3219,10 +3219,10 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  {[key: string]: number}
-        }
-    };
+       }
+};
         }
       }> }) => {  
             status: 200, 
@@ -3310,10 +3310,10 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  {[key: string]: number}
-        }
-    };
+       }
+};
         }
       }> }) => {  
             status: 200, 
@@ -3418,10 +3418,10 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  Order
-        }
-    };
+       }
+};
         },405: {
           headers: {};
           content: {};
@@ -3545,10 +3545,10 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  Order
-        }
-    };
+       }
+};
         },405: {
           headers: {};
           content: {};
@@ -3702,13 +3702,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Order
-        },
+       },
 \\"application/json\\": { 
           schema:  Order
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -3894,13 +3894,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Order
-        },
+       },
 \\"application/json\\": { 
           schema:  Order
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -4090,13 +4090,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  Order
-        },
+       },
 \\"application/json\\": { 
           schema:  Order
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -4300,13 +4300,13 @@ Map {
       [statusCode in HttpStatusCode]: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  User
-        },
+       },
 \\"application/xml\\": { 
           schema:  User
-        }
-    };
+       }
+};
         }
       }> }) => {  
             status: number | undefined, 
@@ -4427,13 +4427,13 @@ Map {
       [statusCode in HttpStatusCode]: {
           headers: {};
           content: {
-      \\"application/json\\": { 
+\\"application/json\\": { 
           schema:  User
-        },
+       },
 \\"application/xml\\": { 
           schema:  User
-        }
-    };
+       }
+};
         }
       }> }) => {  
             status: number | undefined, 
@@ -4570,13 +4570,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  User
-        },
+       },
 \\"application/json\\": { 
           schema:  User
-        }
-    };
+       }
+};
         },[statusCode in Exclude<HttpStatusCode, 200>]: {
           headers: {};
           content: {};
@@ -4704,13 +4704,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  User
-        },
+       },
 \\"application/json\\": { 
           schema:  User
-        }
-    };
+       }
+};
         },[statusCode in Exclude<HttpStatusCode, 200>]: {
           headers: {};
           content: {};
@@ -4851,15 +4851,18 @@ Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: {username?: string, password?: string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
       200: {
-          headers: {\\"X-Rate-Limit\\": { schema: number};\\"X-Expires-After\\": { schema: string}};
+          headers: {
+\\"X-Rate-Limit\\": { schema: number},
+\\"X-Expires-After\\": { schema: string}
+};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  string
-        },
+       },
 \\"application/json\\": { 
           schema:  string
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -4954,15 +4957,18 @@ Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: {username?: string, password?: string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
       200: {
-          headers: {\\"X-Rate-Limit\\": { schema: number};\\"X-Expires-After\\": { schema: string}};
+          headers: {
+\\"X-Rate-Limit\\": { schema: number},
+\\"X-Expires-After\\": { schema: string}
+};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  string
-        },
+       },
 \\"application/json\\": { 
           schema:  string
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -5288,13 +5294,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  User
-        },
+       },
 \\"application/json\\": { 
           schema:  User
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -5532,13 +5538,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  User
-        },
+       },
 \\"application/json\\": { 
           schema:  User
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -5776,13 +5782,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  User
-        },
+       },
 \\"application/json\\": { 
           schema:  User
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};
@@ -6024,13 +6030,13 @@ Map {
       200: {
           headers: {};
           content: {
-      \\"application/xml\\": { 
+\\"application/xml\\": { 
           schema:  User
-        },
+       },
 \\"application/json\\": { 
           schema:  User
-        }
-    };
+       }
+};
         },400: {
           headers: {};
           content: {};

--- a/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
+++ b/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
@@ -56,17 +56,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -94,27 +92,21 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -333,17 +325,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -371,27 +361,21 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -614,17 +598,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -652,27 +634,21 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -909,17 +885,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Array<Pet>
-            },
+          schema:  Array<Pet>
+        },
 \\"application/json\\": { 
-              schema:  Array<Pet>
-            }
+          schema:  Array<Pet>
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -1108,17 +1082,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Array<Pet>
-            },
+          schema:  Array<Pet>
+        },
 \\"application/json\\": { 
-              schema:  Array<Pet>
-            }
+          schema:  Array<Pet>
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -1323,17 +1295,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Array<Pet>
-            },
+          schema:  Array<Pet>
+        },
 \\"application/json\\": { 
-              schema:  Array<Pet>
-            }
+          schema:  Array<Pet>
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -1522,17 +1492,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Array<Pet>
-            },
+          schema:  Array<Pet>
+        },
 \\"application/json\\": { 
-              schema:  Array<Pet>
-            }
+          schema:  Array<Pet>
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -1765,22 +1733,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -1808,9 +1772,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 405 
@@ -1828,9 +1790,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -2075,22 +2035,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -2118,9 +2074,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 405 
@@ -2138,9 +2092,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -2385,22 +2337,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -2428,9 +2376,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 405 
@@ -2448,9 +2394,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -2699,22 +2643,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Pet
-            },
+          schema:  Pet
+        },
 \\"application/json\\": { 
-              schema:  Pet
-            }
+          schema:  Pet
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -2742,9 +2682,7 @@ Map {
         "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 405 
@@ -2762,9 +2700,7 @@ Map {
         "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -3025,8 +2961,8 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  ApiResponse
-            }
+          schema:  ApiResponse
+        }
     };
         }
       }> }) => {  
@@ -3147,8 +3083,8 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  ApiResponse
-            }
+          schema:  ApiResponse
+        }
     };
         }
       }> }) => {  
@@ -3284,8 +3220,8 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  {[key: string]: number}
-            }
+          schema:  {[key: string]: number}
+        }
     };
         }
       }> }) => {  
@@ -3375,8 +3311,8 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  {[key: string]: number}
-            }
+          schema:  {[key: string]: number}
+        }
     };
         }
       }> }) => {  
@@ -3483,14 +3419,12 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  Order
-            }
+          schema:  Order
+        }
     };
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -3612,14 +3546,12 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  Order
-            }
+          schema:  Order
+        }
     };
         },405: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -3771,22 +3703,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Order
-            },
+          schema:  Order
+        },
 \\"application/json\\": { 
-              schema:  Order
-            }
+          schema:  Order
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -3814,14 +3742,10 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -3971,22 +3895,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Order
-            },
+          schema:  Order
+        },
 \\"application/json\\": { 
-              schema:  Order
-            }
+          schema:  Order
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -4014,14 +3934,10 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -4175,22 +4091,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  Order
-            },
+          schema:  Order
+        },
 \\"application/json\\": { 
-              schema:  Order
-            }
+          schema:  Order
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -4218,14 +4130,10 @@ Map {
         "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -4393,11 +4301,11 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/xml\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         }
       }> }) => {  
@@ -4520,11 +4428,11 @@ Map {
           headers: {};
           content: {
       \\"application/json\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/xml\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         }
       }> }) => {  
@@ -4663,17 +4571,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/json\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         },[statusCode in Exclude<HttpStatusCode, 200>]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -4799,17 +4705,15 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/json\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         },[statusCode in Exclude<HttpStatusCode, 200>]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -4950,17 +4854,15 @@ Map {
           headers: {\\"X-Rate-Limit\\": { schema: number};\\"X-Expires-After\\": { schema: string}};
           content: {
       \\"application/xml\\": { 
-              schema:  string
-            },
+          schema:  string
+        },
 \\"application/json\\": { 
-              schema:  string
-            }
+          schema:  string
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -5055,17 +4957,15 @@ Map {
           headers: {\\"X-Rate-Limit\\": { schema: number};\\"X-Expires-After\\": { schema: string}};
           content: {
       \\"application/xml\\": { 
-              schema:  string
-            },
+          schema:  string
+        },
 \\"application/json\\": { 
-              schema:  string
-            }
+          schema:  string
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -5172,9 +5072,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
       [statusCode in HttpStatusCode]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: number | undefined 
@@ -5259,9 +5157,7 @@ Map {
         "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
       [statusCode in HttpStatusCode]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: number | undefined 
@@ -5393,22 +5289,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/json\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -5436,9 +5328,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
       [statusCode in HttpStatusCode]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: number | undefined 
@@ -5456,14 +5346,10 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -5647,22 +5533,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/json\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -5690,9 +5572,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
       [statusCode in HttpStatusCode]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: number | undefined 
@@ -5710,14 +5590,10 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -5901,22 +5777,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/json\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -5944,9 +5816,7 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
       [statusCode in HttpStatusCode]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: number | undefined 
@@ -5964,14 +5834,10 @@ Map {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 
@@ -6159,22 +6025,18 @@ Map {
           headers: {};
           content: {
       \\"application/xml\\": { 
-              schema:  User
-            },
+          schema:  User
+        },
 \\"application/json\\": { 
-              schema:  User
-            }
+          schema:  User
+        }
     };
         },400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 200, 
@@ -6202,9 +6064,7 @@ Map {
         "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
       [statusCode in HttpStatusCode]: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: number | undefined 
@@ -6222,14 +6082,10 @@ Map {
         "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
       400: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         },404: {
           headers: {};
-          content: {
-      
-    };
+          content: {};
         }
       }> }) => {  
             status: 400 

--- a/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
+++ b/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
@@ -52,7 +52,7 @@ Map {
           "exports": Map {
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -62,11 +62,12 @@ Map {
           schema:  Pet
        }
 };
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -88,7 +89,7 @@ Map {
             },
             "HTTP_PUT" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -98,17 +99,20 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -321,7 +325,7 @@ Map {
           "exports": Map {
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -331,11 +335,12 @@ Map {
           schema:  Pet
        }
 };
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -357,7 +362,7 @@ Map {
             },
             "HTTP_PUT" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -367,17 +372,20 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -594,7 +602,7 @@ Map {
     "exports": Map {
       "HTTP_POST" => Object {
         "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -604,11 +612,12 @@ Map {
           schema:  Pet
        }
 };
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -630,7 +639,7 @@ Map {
       },
       "HTTP_PUT" => Object {
         "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -640,17 +649,20 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -881,7 +893,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: {status?: string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -891,11 +903,12 @@ Map {
           schema:  Array<Pet>
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Array<Pet>
@@ -1078,7 +1091,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: {status?: string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -1088,11 +1101,12 @@ Map {
           schema:  Array<Pet>
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Array<Pet>
@@ -1291,7 +1305,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: {tags?: Array<string>}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -1301,11 +1315,12 @@ Map {
           schema:  Array<Pet>
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Array<Pet>
@@ -1488,7 +1503,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: {tags?: Array<string>}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -1498,11 +1513,12 @@ Map {
           schema:  Array<Pet>
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Array<Pet>
@@ -1729,7 +1745,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -1739,14 +1755,16 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -1770,11 +1788,11 @@ Map {
             },
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      405: {
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 405 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -1788,11 +1806,11 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2031,7 +2049,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -2041,14 +2059,16 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -2072,11 +2092,11 @@ Map {
             },
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      405: {
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 405 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2090,11 +2110,11 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2333,7 +2353,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -2343,14 +2363,16 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -2374,11 +2396,11 @@ Map {
             },
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      405: {
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 405 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2392,11 +2414,11 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2639,7 +2661,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {petId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -2649,14 +2671,16 @@ Map {
           schema:  Pet
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Pet
@@ -2680,11 +2704,11 @@ Map {
       },
       "HTTP_POST" => Object {
         "code": "({ query, path, header, body, context }: { query: {name?: number, status?: string}, path: {petId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      405: {
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 405 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2698,11 +2722,11 @@ Map {
       },
       "HTTP_DELETE" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {petId: string}, header: {api_key?: string}, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -2957,7 +2981,7 @@ Map {
           "exports": Map {
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: {additionalMetadata?: number}, path: {petId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/json\\": { 
@@ -2965,7 +2989,7 @@ Map {
        }
 };
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/json\\",
             body?: ApiResponse
@@ -3079,7 +3103,7 @@ Map {
     "exports": Map {
       "HTTP_POST" => Object {
         "code": "({ query, path, header, body, context }: { query: {additionalMetadata?: number}, path: {petId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/json\\": { 
@@ -3087,7 +3111,7 @@ Map {
        }
 };
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/json\\",
             body?: ApiResponse
@@ -3216,7 +3240,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/json\\": { 
@@ -3224,7 +3248,7 @@ Map {
        }
 };
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/json\\",
             body?: {[key: string]: number}
@@ -3307,7 +3331,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/json\\": { 
@@ -3315,7 +3339,7 @@ Map {
        }
 };
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/json\\",
             body?: {[key: string]: number}
@@ -3415,18 +3439,19 @@ Map {
           "exports": Map {
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/json\\": { 
           schema:  Order
        }
 };
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/json\\",
             body?: Order
@@ -3542,18 +3567,19 @@ Map {
     "exports": Map {
       "HTTP_POST" => Object {
         "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/json\\": { 
           schema:  Order
        }
 };
-        },405: {
+        },
+405: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/json\\",
             body?: Order
@@ -3699,7 +3725,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -3709,14 +3735,16 @@ Map {
           schema:  Order
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Order
@@ -3740,14 +3768,15 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 
@@ -3891,7 +3920,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -3901,14 +3930,16 @@ Map {
           schema:  Order
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Order
@@ -3932,14 +3963,15 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 
@@ -4087,7 +4119,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -4097,14 +4129,16 @@ Map {
           schema:  Order
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: Order
@@ -4128,14 +4162,15 @@ Map {
       },
       "HTTP_DELETE" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {orderId: number}, header: never, body: undefined, context: typeof Context2, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 
@@ -4297,7 +4332,7 @@ Map {
           "exports": Map {
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: User, context: typeof Context, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {
 \\"application/json\\": { 
@@ -4308,7 +4343,7 @@ Map {
        }
 };
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined, 
             contentType?: \\"application/json\\",
             body?: User
@@ -4424,7 +4459,7 @@ Map {
     "exports": Map {
       "HTTP_POST" => Object {
         "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: User, context: typeof Context, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {
 \\"application/json\\": { 
@@ -4435,7 +4470,7 @@ Map {
        }
 };
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined, 
             contentType?: \\"application/json\\",
             body?: User
@@ -4567,7 +4602,7 @@ Map {
           "exports": Map {
             "HTTP_POST" => Object {
               "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -4577,11 +4612,12 @@ Map {
           schema:  User
        }
 };
-        },[statusCode in Exclude<HttpStatusCode, 200>]: {
+        },
+[statusCode in Exclude<HttpStatusCode, 200>]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: User
@@ -4701,7 +4737,7 @@ Map {
     "exports": Map {
       "HTTP_POST" => Object {
         "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -4711,11 +4747,12 @@ Map {
           schema:  User
        }
 };
-        },[statusCode in Exclude<HttpStatusCode, 200>]: {
+        },
+[statusCode in Exclude<HttpStatusCode, 200>]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: User
@@ -4850,7 +4887,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: {username?: string, password?: string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {
 \\"X-Rate-Limit\\": { schema: number},
 \\"X-Expires-After\\": { schema: string}
@@ -4863,11 +4900,12 @@ Map {
           schema:  string
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: string
@@ -4956,7 +4994,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: {username?: string, password?: string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {
 \\"X-Rate-Limit\\": { schema: number},
 \\"X-Expires-After\\": { schema: string}
@@ -4969,11 +5007,12 @@ Map {
           schema:  string
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: string
@@ -5076,11 +5115,11 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -5161,11 +5200,11 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -5291,7 +5330,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -5301,14 +5340,16 @@ Map {
           schema:  User
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: User
@@ -5332,11 +5373,11 @@ Map {
             },
             "HTTP_PUT" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -5350,14 +5391,15 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 
@@ -5535,7 +5577,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -5545,14 +5587,16 @@ Map {
           schema:  User
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: User
@@ -5576,11 +5620,11 @@ Map {
             },
             "HTTP_PUT" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -5594,14 +5638,15 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 
@@ -5779,7 +5824,7 @@ Map {
           "exports": Map {
             "HTTP_GET" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -5789,14 +5834,16 @@ Map {
           schema:  User
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: User
@@ -5820,11 +5867,11 @@ Map {
             },
             "HTTP_PUT" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -5838,14 +5885,15 @@ Map {
             },
             "HTTP_DELETE" => Object {
               "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 
@@ -6027,7 +6075,7 @@ Map {
     "exports": Map {
       "HTTP_GET" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
-      200: {
+200: {
           headers: {};
           content: {
 \\"application/xml\\": { 
@@ -6037,14 +6085,16 @@ Map {
           schema:  User
        }
 };
-        },400: {
+        },
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 200, 
             contentType?: \\"application/xml\\",
             body?: User
@@ -6068,11 +6118,11 @@ Map {
       },
       "HTTP_PUT" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: User, context: typeof Context2, response: ResponseBuilderFactory<{
-      [statusCode in HttpStatusCode]: {
+[statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: number | undefined 
           } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
@@ -6086,14 +6136,15 @@ Map {
       },
       "HTTP_DELETE" => Object {
         "code": "({ query, path, header, body, context }: { query: never, path: {username: string}, header: never, body: undefined, context: typeof Context3, response: ResponseBuilderFactory<{
-      400: {
+400: {
           headers: {};
           content: {};
-        },404: {
+        },
+404: {
           headers: {};
           content: {};
         }
-      }> }) => {  
+}> }) => {  
             status: 400 
           } | {  
             status: 404 

--- a/test/typescript-generator/integration.test.js
+++ b/test/typescript-generator/integration.test.js
@@ -35,8 +35,8 @@ describe("integration Test", () => {
       }
     }
 
-    requirement.forEach(([key, pathDefinition]) => {
-      pathDefinition.forEach(([, operation]) => {
+    requirement.forEach((pathDefinition, key) => {
+      pathDefinition.forEach((operation) => {
         repository.get(`paths${key}.ts`).export(new OperationCoder(operation));
       });
     });

--- a/test/typescript-generator/requirement.test.js
+++ b/test/typescript-generator/requirement.test.js
@@ -61,8 +61,8 @@ describe("a Requirement", () => {
 
     const result = [];
 
-    requirement.forEach((entry) => {
-      result.push(entry);
+    requirement.forEach((value, key) => {
+      result.push([key, value]);
     });
 
     expect(result).toStrictEqual([

--- a/test/typescript-generator/requirement.test.js
+++ b/test/typescript-generator/requirement.test.js
@@ -83,7 +83,7 @@ describe("a Requirement", () => {
     const address = requirement.select("address");
     const specialChars = requirement.select("foo~1bar~0baz");
 
-    const result = requirement.map(([key, subRequirement]) => [
+    const result = requirement.map((subRequirement, key) => [
       `${key}!`,
       subRequirement,
     ]);

--- a/test/typescript-generator/requirement.test.js
+++ b/test/typescript-generator/requirement.test.js
@@ -102,7 +102,7 @@ describe("a Requirement", () => {
       b: "bar",
     });
 
-    const result = requirement.flatMap(([key, subRequirement]) => [
+    const result = requirement.flatMap((subRequirement, key) => [
       `${key}: ${subRequirement.data} 1`,
 
       `${key}: ${subRequirement.data} 2`,

--- a/test/typescript-generator/response-type-coder.test.js
+++ b/test/typescript-generator/response-type-coder.test.js
@@ -2,14 +2,41 @@ import { ResponseTypeCoder } from "../../src/typescript-generator/response-type-
 
 describe("a ResponseTypeCoder", () => {
   it("creates a type for a status code", () => {
-    const coder = new ResponseTypeCoder();
+    const coder = new ResponseTypeCoder({
+      data: {
+        200: {},
+        default: {},
+      },
+    });
 
-    expect(coder.normalizeStatusCode("200", { default: {} })).toBe("200");
-    expect(coder.normalizeStatusCode("default", { default: {} })).toBe(
-      "[statusCode in HttpStatusCode]"
+    expect(coder.normalizeStatusCode("200", { 200: {}, default: {} })).toBe(
+      "200"
     );
+  });
+
+  it("creates a type for a default status code when some status codes are defined", () => {
+    const coder = new ResponseTypeCoder({
+      data: {
+        default: {},
+        200: {},
+        201: {},
+      },
+    });
+
     expect(coder.normalizeStatusCode("default", { 200: {}, 201: {} })).toBe(
       "[statusCode in Exclude<HttpStatusCode, 200 | 201>]"
+    );
+  });
+
+  it("creates a type for a default status code when its the only entry, so it could represent any status code", () => {
+    const coder = new ResponseTypeCoder({
+      data: {
+        default: {},
+      },
+    });
+
+    expect(coder.normalizeStatusCode("default", { default: {} })).toBe(
+      "[statusCode in HttpStatusCode]"
     );
   });
 });


### PR DESCRIPTION
- change flatMap signature so the callback is (value, key) => result
- change requirement.map signature so the callback is (value, key) => result
- now that map() is refactored, flatMap() can got back to delegating to it
- change requirement.forEach signature so the callback is (value, key) => result
- refactor responseTypeCoder.normalizeStatusCode()
- simplify ResponseTypeCoder.buildContentObjectType
- simplify responseTypeCoder.buildHeaders
- rename variable for consistency with buildHeaders
- new printObjectFromEntries() function
- use printObjectFromEntries() in responseTypeCoder.buildHeaders()
- refactor ResponseTypeCoder so few arguments are passed around
- teasing apart ASTs and printers a little bit at a time


Some things I'm thinking about next:

1. There's an opportunity now for `requirement.get(key)` to return a NullRequirement instead of `undefined`.
2. Might want to `.keys()`, `.values()`, and `.entries()` to `Requirement`. 
3. I don't like `requirement.data`. I think it should be `requirement.value`. 
4. Still lots of low-hanging fruit in the `typescript-generator` 
5. Need to add more unit tests and rely less on snapshots 