### PR TITLE
OpenAPI 2 support

### DIFF
--- a/.changeset/shaggy-snakes-trade.md
+++ b/.changeset/shaggy-snakes-trade.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+Experimental support for OpenAPI 2

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "eslint . --plugin file-progress --rule 'file-progress/activate: 1'",
     "lint:quickfix": "eslint --fix . eslint --fix demo-ts --rule=\"import/namespace: 0,etc/no-deprecated:0,import/no-cycle:0,no-explicit-type-exports/no-explicit-type-exports:0,import/no-deprecated:0,import/no-self-import:0,import/default:0,import/no-named-as-default:0\"",
     "go:petstore": "yarn counterfact  https://petstore3.swagger.io/api/v3/openapi.json out --open",
+    "go:petstore2": "yarn counterfact  https://petstore.swagger.io/v2/swagger.json out",
     "go:example": "yarn counterfact ./openapi-example.yaml out --open",
     "counterfact": "./bin/counterfact.js"
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "prepare": "husky install",
     "lint": "eslint . --plugin file-progress --rule 'file-progress/activate: 1'",
     "lint:quickfix": "eslint --fix . eslint --fix demo-ts --rule=\"import/namespace: 0,etc/no-deprecated:0,import/no-cycle:0,no-explicit-type-exports/no-explicit-type-exports:0,import/no-deprecated:0,import/no-self-import:0,import/default:0,import/no-named-as-default:0\"",
-    "go:petstore": "yarn counterfact  https://petstore3.swagger.io/api/v3/openapi.json out --open",
+    "go:petstore": "yarn counterfact  https://petstore3.swagger.io/api/v3/openapi.json out",
     "go:petstore2": "yarn counterfact  https://petstore.swagger.io/v2/swagger.json out",
     "go:example": "yarn counterfact ./openapi-example.yaml out --open",
     "counterfact": "./bin/counterfact.js"

--- a/src/server/counterfact.js
+++ b/src/server/counterfact.js
@@ -15,9 +15,6 @@ import { ModuleLoader } from "./module-loader.js";
 import { Transpiler } from "./transpiler.js";
 import { ContextRegistry } from "./context-registry.js";
 
-// eslint-disable-next-line no-underscore-dangle
-const __dirname = nodePath.dirname(new URL(import.meta.url).pathname);
-
 async function loadOpenApiDocument(source) {
   try {
     return $RefParser.dereference(await yaml.load(await readFile(source)));
@@ -38,11 +35,6 @@ export async function counterfact(
   const modulesPath = `${await fs.mkdtemp(
     nodePath.join(os.tmpdir(), "counterfact-")
   )}/`;
-
-  fs.copyFile(
-    nodePath.join(__dirname, "../../templates/response-builder-factory.ts"),
-    nodePath.join(basePath, "response-builder-factory.ts")
-  );
 
   try {
     await fs.writeFile(

--- a/src/typescript-generator/generate.js
+++ b/src/typescript-generator/generate.js
@@ -1,12 +1,6 @@
-import fs from "node:fs/promises";
-import nodePath from "node:path";
-
 import { Repository } from "./repository.js";
 import { Specification } from "./specification.js";
 import { OperationCoder } from "./operation-coder.js";
-
-// eslint-disable-next-line no-underscore-dangle
-const __dirname = nodePath.dirname(new URL(import.meta.url).pathname);
 
 export async function generate(
   source,
@@ -24,9 +18,4 @@ export async function generate(
   });
 
   await repository.writeFiles(destination);
-
-  fs.copyFile(
-    nodePath.join(__dirname, "../../templates/response-builder-factory.ts"),
-    nodePath.join(destination, "response-builder-factory.ts")
-  );
 }

--- a/src/typescript-generator/generate.js
+++ b/src/typescript-generator/generate.js
@@ -1,6 +1,12 @@
+import fs from "node:fs/promises";
+import nodePath from "node:path";
+
 import { Repository } from "./repository.js";
 import { Specification } from "./specification.js";
 import { OperationCoder } from "./operation-coder.js";
+
+// eslint-disable-next-line no-underscore-dangle
+const __dirname = nodePath.dirname(new URL(import.meta.url).pathname);
 
 export async function generate(
   source,
@@ -18,4 +24,9 @@ export async function generate(
   });
 
   await repository.writeFiles(destination);
+
+  fs.copyFile(
+    nodePath.join(__dirname, "../../templates/response-builder-factory.ts"),
+    nodePath.join(destination, "response-builder-factory.ts")
+  );
 }

--- a/src/typescript-generator/operation-coder.js
+++ b/src/typescript-generator/operation-coder.js
@@ -21,7 +21,7 @@ export class OperationCoder extends Coder {
     );
     const [firstResponse] = responses.map((response) => response.data);
 
-    if (!("content" in firstResponse)) {
+    if (!("content" in firstResponse || "schema" in firstResponse)) {
       return "() => { /* no response content specified in the OpenAPI document */ }";
     }
 

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -71,17 +71,17 @@ export class OperationTypeCoder extends Coder {
 
     const queryType =
       parameters === undefined
-        ? "undefined"
+        ? "never"
         : new ParametersTypeCoder(parameters, "query").write(script);
 
     const pathType =
       parameters === undefined
-        ? "undefined"
+        ? "never"
         : new ParametersTypeCoder(parameters, "path").write(script);
 
     const headerType =
       parameters === undefined
-        ? "undefined"
+        ? "never"
         : new ParametersTypeCoder(parameters, "header").write(script);
 
     const bodyRequirement = this.requirement.get("consumes")

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -84,9 +84,14 @@ export class OperationTypeCoder extends Coder {
         ? "undefined"
         : new ParametersTypeCoder(parameters, "header").write(script);
 
-    const bodyRequirement = this.requirement.select(
-      "requestBody/content/application~1json/schema"
-    );
+    const bodyRequirement = this.requirement.get("consumes")
+      ? this.requirement
+          .get("parameters")
+          .find((parameter) =>
+            ["body", "formData"].includes(parameter.get("in").data)
+          )
+          .get("schema")
+      : this.requirement.select("requestBody/content/application~1json/schema");
 
     const bodyType = bodyRequirement
       ? new SchemaTypeCoder(bodyRequirement).write(script)

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -32,6 +32,19 @@ export class OperationTypeCoder extends Coder {
           );
         }
 
+        if (response.has("schema")) {
+          return this.requirement
+            .get("produces")
+            .data.map(
+              (contentType) => `{
+            status: ${status},
+            contentType?: "${contentType}",
+            body?: ${new SchemaTypeCoder(response.get("schema")).write(script)}
+          }`
+            )
+            .join(" | ");
+        }
+
         return `{  
           status: ${status} 
         }`;

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -22,19 +22,19 @@ export class OperationTypeCoder extends Coder {
             ? "number | undefined"
             : Number.parseInt(responseCode, 10);
 
-        if (!response.has("content")) {
-          return `{  
-            status: ${status} 
-          }`;
+        if (response.has("content")) {
+          return response.get("content").map(
+            (content, contentType) => `{  
+              status: ${status}, 
+              contentType?: "${contentType}",
+              body?: ${new SchemaTypeCoder(content.get("schema")).write(script)}
+            }`
+          );
         }
 
-        return response.get("content").map(
-          (content, contentType) => `{  
-            status: ${status}, 
-            contentType?: "${contentType}",
-            body?: ${new SchemaTypeCoder(content.get("schema")).write(script)}
-          }`
-        );
+        return `{  
+          status: ${status} 
+        }`;
       })
 
       .join(" | ");

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -93,7 +93,8 @@ export class OperationTypeCoder extends Coder {
       : "undefined";
 
     const responseType = new ResponseTypeCoder(
-      this.requirement.get("responses")
+      this.requirement.get("responses"),
+      this.requirement.get("produces")?.data
     ).write(script);
 
     return `({ query, path, header, body, context }: { query: ${queryType}, path: ${pathType}, header: ${headerType}, body: ${bodyType}, context: typeof ${contextImportName}, response: ${responseType} }) => ${this.responseTypes(

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -55,6 +55,7 @@ export class OperationTypeCoder extends Coder {
     );
 
     const parameters = this.requirement.get("parameters");
+
     const queryType =
       parameters === undefined
         ? "undefined"

--- a/src/typescript-generator/parameters-type-coder.js
+++ b/src/typescript-generator/parameters-type-coder.js
@@ -28,9 +28,13 @@ export class ParametersTypeCoder extends Coder {
 
         const optionalFlag = required ? "" : "?";
 
-        return `${name}${optionalFlag}: ${new SchemaTypeCoder(
-          requirement.get("schema")
-        ).write(script)}`;
+        const schema = requirement.has("schema")
+          ? requirement.get("schema")
+          : requirement;
+
+        return `${name}${optionalFlag}: ${new SchemaTypeCoder(schema).write(
+          script
+        )}`;
       });
 
     if (typeDefinitions.length === 0) {

--- a/src/typescript-generator/parameters-type-coder.js
+++ b/src/typescript-generator/parameters-type-coder.js
@@ -16,7 +16,7 @@ export class ParametersTypeCoder extends Coder {
 
   write(script) {
     if (!this.requirement) {
-      return "undefined";
+      return "never";
     }
 
     const typeDefinitions = this.requirement.data

--- a/src/typescript-generator/repository.js
+++ b/src/typescript-generator/repository.js
@@ -6,6 +6,9 @@ import prettier from "prettier";
 
 import { Script } from "./script.js";
 
+// eslint-disable-next-line no-underscore-dangle
+const __dirname = nodePath.dirname(new URL(import.meta.url).pathname);
+
 async function ensureDirectoryExists(filePath) {
   const directory = nodePath.dirname(filePath);
 
@@ -44,6 +47,17 @@ export class Repository {
     }
   }
 
+  copyCoreFiles(destination) {
+    const path = nodePath.join(destination, "response-builder-factory.ts");
+
+    process.stdout.write(`writing ${path}\n`);
+
+    return fs.copyFile(
+      nodePath.join(__dirname, "../../templates/response-builder-factory.ts"),
+      path
+    );
+  }
+
   async writeFiles(destination) {
     await this.finished();
 
@@ -77,5 +91,7 @@ export class Repository {
     );
 
     await Promise.all(writeFiles);
+
+    await this.copyCoreFiles(destination);
   }
 }

--- a/src/typescript-generator/requirement.js
+++ b/src/typescript-generator/requirement.js
@@ -81,6 +81,20 @@ export class Requirement {
     return this.map(callback).flat();
   }
 
+  find(callback) {
+    // eslint-disable-next-line init-declarations
+    let result;
+
+    this.forEach((value, key) => {
+      // eslint-disable-next-line node/callback-return
+      if (result === undefined && callback(value, key)) {
+        result = value;
+      }
+    });
+
+    return result;
+  }
+
   escapeJsonPointer(string) {
     return string.replaceAll("~", "~0").replaceAll("/", "~1");
   }

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -28,16 +28,16 @@ export class ResponseTypeCoder extends Coder {
   }
 
   buildContentObjectType(script, response) {
-    if (!response.has("content")) {
-      return "{}";
+    if (response.has("content")) {
+      return response.get("content").map((content, mediaType) => [
+        mediaType,
+        `{ 
+            schema:  ${new SchemaTypeCoder(content.get("schema")).write(script)}
+         }`,
+      ]);
     }
 
-    return response.get("content").map((content, mediaType) => [
-      mediaType,
-      `{ 
-          schema:  ${new SchemaTypeCoder(content.get("schema")).write(script)}
-       }`,
-    ]);
+    return "{}";
   }
 
   printContentObjectType(script, response) {

--- a/src/typescript-generator/response-type-coder.js
+++ b/src/typescript-generator/response-type-coder.js
@@ -53,7 +53,9 @@ export class ResponseTypeCoder extends Coder {
       .get("headers")
       .map((value, name) => [
         name,
-        `{ schema: ${new SchemaTypeCoder(value.get("schema")).write(script)}}`,
+        `{ schema: ${new SchemaTypeCoder(value.get("schema") ?? value).write(
+          script
+        )}}`,
       ]);
   }
 

--- a/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
+++ b/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
@@ -68,16 +68,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet/post",
@@ -113,20 +113,20 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet/put",
@@ -341,16 +341,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet/post",
@@ -386,20 +386,20 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet/put",
@@ -618,16 +618,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet/post",
@@ -663,20 +663,20 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet/put",
@@ -909,16 +909,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Array<Pet>
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Array<Pet>
-          } | {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Array<Pet>
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Array<Pet>
+            } | {  
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1findByStatus/get",
@@ -1107,16 +1107,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Array<Pet>
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Array<Pet>
-          } | {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Array<Pet>
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Array<Pet>
+            } | {  
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1findByStatus/get",
@@ -1321,16 +1321,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Array<Pet>
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Array<Pet>
-          } | {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Array<Pet>
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Array<Pet>
+            } | {  
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1findByTags/get",
@@ -1519,16 +1519,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Array<Pet>
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Array<Pet>
-          } | {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Array<Pet>
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Array<Pet>
+            } | {  
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1findByTags/get",
@@ -1765,18 +1765,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/get",
@@ -1793,8 +1793,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/post",
@@ -1811,8 +1811,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/delete",
@@ -2069,18 +2069,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/get",
@@ -2097,8 +2097,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/post",
@@ -2115,8 +2115,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/delete",
@@ -2373,18 +2373,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/get",
@@ -2401,8 +2401,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/post",
@@ -2419,8 +2419,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/delete",
@@ -2681,18 +2681,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Pet
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Pet
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Pet
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Pet
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/get",
@@ -2709,8 +2709,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/post",
@@ -2727,8 +2727,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}/delete",
@@ -2990,10 +2990,10 @@ Map {
 };
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: ApiResponse
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: ApiResponse
+            } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}~1uploadImage/post",
@@ -3112,10 +3112,10 @@ Map {
 };
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: ApiResponse
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: ApiResponse
+            } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1pet~1{petId}~1uploadImage/post",
@@ -3249,10 +3249,10 @@ Map {
 };
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: {[key: string]: number}
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: {[key: string]: number}
+            } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1inventory/get",
@@ -3340,10 +3340,10 @@ Map {
 };
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: {[key: string]: number}
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: {[key: string]: number}
+            } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1inventory/get",
@@ -3452,12 +3452,12 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Order
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Order
+            } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order/post",
@@ -3580,12 +3580,12 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Order
-          } | {  
-            status: 405 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Order
+            } | {  
+          status: 405 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order/post",
@@ -3745,18 +3745,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Order
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Order
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Order
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Order
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order~1{orderId}/get",
@@ -3777,10 +3777,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order~1{orderId}/delete",
@@ -3940,18 +3940,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Order
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Order
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Order
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Order
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order~1{orderId}/get",
@@ -3972,10 +3972,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order~1{orderId}/delete",
@@ -4139,18 +4139,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: Order
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: Order
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: Order
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: Order
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order~1{orderId}/get",
@@ -4171,10 +4171,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1store~1order~1{orderId}/delete",
@@ -4344,14 +4344,14 @@ Map {
 };
         }
 }> }) => {  
-            status: number | undefined, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: number | undefined, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: number | undefined, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+              status: number | undefined, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user/post",
@@ -4471,14 +4471,14 @@ Map {
 };
         }
 }> }) => {  
-            status: number | undefined, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: number | undefined, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: number | undefined, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+              status: number | undefined, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user/post",
@@ -4618,16 +4618,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1createWithList/post",
@@ -4753,16 +4753,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1createWithList/post",
@@ -4906,16 +4906,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: string
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: string
-          } | {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: string
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: string
+            } | {  
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1login/get",
@@ -5013,16 +5013,16 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: string
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: string
-          } | {  
-            status: 400 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: string
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: string
+            } | {  
+          status: 400 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1login/get",
@@ -5120,8 +5120,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1logout/get",
@@ -5205,8 +5205,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1logout/get",
@@ -5350,18 +5350,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/get",
@@ -5378,8 +5378,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/put",
@@ -5400,10 +5400,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/delete",
@@ -5597,18 +5597,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/get",
@@ -5625,8 +5625,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/put",
@@ -5647,10 +5647,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/delete",
@@ -5844,18 +5844,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/get",
@@ -5872,8 +5872,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/put",
@@ -5894,10 +5894,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
               "done": true,
               "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/delete",
@@ -6095,18 +6095,18 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 200, 
-            contentType?: \\"application/xml\\",
-            body?: User
-          } | {  
-            status: 200, 
-            contentType?: \\"application/json\\",
-            body?: User
-          } | {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+              status: 200, 
+              contentType?: \\"application/xml\\",
+              body?: User
+            } | {  
+              status: 200, 
+              contentType?: \\"application/json\\",
+              body?: User
+            } | {  
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/get",
@@ -6123,8 +6123,8 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: number | undefined 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: number | undefined 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/put",
@@ -6145,10 +6145,10 @@ Map {
           content: {};
         }
 }> }) => {  
-            status: 400 
-          } | {  
-            status: 404 
-          } | { status: 415, contentType: \\"text/plain\\", body: string }
+          status: 400 
+        } | {  
+          status: 404 
+        } | { status: 415, contentType: \\"text/plain\\", body: string }
     | void",
         "done": true,
         "id": "OperationTypeCoder@petstore.yaml#/paths/~1user~1{username}/delete",

--- a/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
+++ b/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
@@ -56,11 +56,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 405: {
@@ -93,11 +93,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -329,11 +329,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 405: {
@@ -366,11 +366,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -606,11 +606,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 405: {
@@ -643,11 +643,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -897,11 +897,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Array<Pet>
-       },
+            schema:  Array<Pet>
+         },
 \\"application/json\\": { 
-          schema:  Array<Pet>
-       }
+            schema:  Array<Pet>
+         }
 };
         },
 400: {
@@ -1095,11 +1095,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Array<Pet>
-       },
+            schema:  Array<Pet>
+         },
 \\"application/json\\": { 
-          schema:  Array<Pet>
-       }
+            schema:  Array<Pet>
+         }
 };
         },
 400: {
@@ -1309,11 +1309,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Array<Pet>
-       },
+            schema:  Array<Pet>
+         },
 \\"application/json\\": { 
-          schema:  Array<Pet>
-       }
+            schema:  Array<Pet>
+         }
 };
         },
 400: {
@@ -1507,11 +1507,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Array<Pet>
-       },
+            schema:  Array<Pet>
+         },
 \\"application/json\\": { 
-          schema:  Array<Pet>
-       }
+            schema:  Array<Pet>
+         }
 };
         },
 400: {
@@ -1749,11 +1749,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -2053,11 +2053,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -2357,11 +2357,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -2665,11 +2665,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Pet
-       },
+            schema:  Pet
+         },
 \\"application/json\\": { 
-          schema:  Pet
-       }
+            schema:  Pet
+         }
 };
         },
 400: {
@@ -2985,8 +2985,8 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  ApiResponse
-       }
+            schema:  ApiResponse
+         }
 };
         }
 }> }) => {  
@@ -3107,8 +3107,8 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  ApiResponse
-       }
+            schema:  ApiResponse
+         }
 };
         }
 }> }) => {  
@@ -3244,8 +3244,8 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  {[key: string]: number}
-       }
+            schema:  {[key: string]: number}
+         }
 };
         }
 }> }) => {  
@@ -3335,8 +3335,8 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  {[key: string]: number}
-       }
+            schema:  {[key: string]: number}
+         }
 };
         }
 }> }) => {  
@@ -3443,8 +3443,8 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  Order
-       }
+            schema:  Order
+         }
 };
         },
 405: {
@@ -3571,8 +3571,8 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  Order
-       }
+            schema:  Order
+         }
 };
         },
 405: {
@@ -3729,11 +3729,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Order
-       },
+            schema:  Order
+         },
 \\"application/json\\": { 
-          schema:  Order
-       }
+            schema:  Order
+         }
 };
         },
 400: {
@@ -3924,11 +3924,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Order
-       },
+            schema:  Order
+         },
 \\"application/json\\": { 
-          schema:  Order
-       }
+            schema:  Order
+         }
 };
         },
 400: {
@@ -4123,11 +4123,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  Order
-       },
+            schema:  Order
+         },
 \\"application/json\\": { 
-          schema:  Order
-       }
+            schema:  Order
+         }
 };
         },
 400: {
@@ -4336,11 +4336,11 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/xml\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         }
 }> }) => {  
@@ -4463,11 +4463,11 @@ Map {
           headers: {};
           content: {
 \\"application/json\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/xml\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         }
 }> }) => {  
@@ -4606,11 +4606,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/json\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         },
 [statusCode in Exclude<HttpStatusCode, 200>]: {
@@ -4741,11 +4741,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/json\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         },
 [statusCode in Exclude<HttpStatusCode, 200>]: {
@@ -4894,11 +4894,11 @@ Map {
 };
           content: {
 \\"application/xml\\": { 
-          schema:  string
-       },
+            schema:  string
+         },
 \\"application/json\\": { 
-          schema:  string
-       }
+            schema:  string
+         }
 };
         },
 400: {
@@ -5001,11 +5001,11 @@ Map {
 };
           content: {
 \\"application/xml\\": { 
-          schema:  string
-       },
+            schema:  string
+         },
 \\"application/json\\": { 
-          schema:  string
-       }
+            schema:  string
+         }
 };
         },
 400: {
@@ -5334,11 +5334,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/json\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         },
 400: {
@@ -5581,11 +5581,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/json\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         },
 400: {
@@ -5828,11 +5828,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/json\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         },
 400: {
@@ -6079,11 +6079,11 @@ Map {
           headers: {};
           content: {
 \\"application/xml\\": { 
-          schema:  User
-       },
+            schema:  User
+         },
 \\"application/json\\": { 
-          schema:  User
-       }
+            schema:  User
+         }
 };
         },
 400: {

--- a/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
+++ b/test/typescript-generator/__snapshots__/end-to-end.test.js.snap
@@ -51,7 +51,7 @@ Map {
           },
           "exports": Map {
             "HTTP_POST" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -88,7 +88,7 @@ Map {
               "typeDeclaration": "",
             },
             "HTTP_PUT" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -324,7 +324,7 @@ Map {
           },
           "exports": Map {
             "HTTP_POST" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -361,7 +361,7 @@ Map {
               "typeDeclaration": "",
             },
             "HTTP_PUT" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -601,7 +601,7 @@ Map {
     },
     "exports": Map {
       "HTTP_POST" => Object {
-        "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -638,7 +638,7 @@ Map {
         "typeDeclaration": "",
       },
       "HTTP_PUT" => Object {
-        "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Pet, context: typeof Context2, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3239,7 +3239,7 @@ Map {
           },
           "exports": Map {
             "HTTP_GET" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3330,7 +3330,7 @@ Map {
     },
     "exports": Map {
       "HTTP_GET" => Object {
-        "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3438,7 +3438,7 @@ Map {
           },
           "exports": Map {
             "HTTP_POST" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3566,7 +3566,7 @@ Map {
     },
     "exports": Map {
       "HTTP_POST" => Object {
-        "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -4331,7 +4331,7 @@ Map {
           },
           "exports": Map {
             "HTTP_POST" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {
@@ -4458,7 +4458,7 @@ Map {
     },
     "exports": Map {
       "HTTP_POST" => Object {
-        "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {
@@ -4601,7 +4601,7 @@ Map {
           },
           "exports": Map {
             "HTTP_POST" => Object {
-              "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -4736,7 +4736,7 @@ Map {
     },
     "exports": Map {
       "HTTP_POST" => Object {
-        "code": "({ query, path, header, body, context }: { query: undefined, path: undefined, header: undefined, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context }: { query: never, path: never, header: never, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {

--- a/test/typescript-generator/__snapshots__/operation-type-coder.test.js.snap
+++ b/test/typescript-generator/__snapshots__/operation-type-coder.test.js.snap
@@ -68,9 +68,9 @@ exports[`an OperationTypeCoder generates a simple get operation 1`] = `
   body,
   context,
 }: {
-  query: undefined;
-  path: undefined;
-  header: undefined;
+  query: never;
+  path: never;
+  header: never;
   body: undefined;
   context: typeof default;
   response: ResponseBuilderFactory<{

--- a/test/typescript-generator/__snapshots__/parameters-type-coder.test.js.snap
+++ b/test/typescript-generator/__snapshots__/parameters-type-coder.test.js.snap
@@ -5,6 +5,21 @@ exports[`a ParametersTypeCoder generates type never when there is no match 1`] =
 "
 `;
 
+exports[`a ParametersTypeCoder generates types for parameters (OAS2): header 1`] = `
+"type TestType = { name?: string };
+"
+`;
+
+exports[`a ParametersTypeCoder generates types for parameters (OAS2): path 1`] = `
+"type TestType = { id: string };
+"
+`;
+
+exports[`a ParametersTypeCoder generates types for parameters (OAS2): query 1`] = `
+"type TestType = { name?: string; age?: string };
+"
+`;
+
 exports[`a ParametersTypeCoder generates types for parameters: header 1`] = `
 "type TestType = { name?: string };
 "

--- a/test/typescript-generator/parameters-type-coder.test.js
+++ b/test/typescript-generator/parameters-type-coder.test.js
@@ -44,6 +44,29 @@ describe("a ParametersTypeCoder", () => {
     );
   });
 
+  it("generates types for parameters (OAS2)", () => {
+    const requirement = new Requirement([
+      { name: "id", in: "path", type: "string", required: true },
+      { name: "name", in: "query", type: "string" },
+      { name: "age", in: "query", type: "number" },
+      { name: "name", in: "header", type: "string" },
+    ]);
+
+    const pathCoder = new ParametersTypeCoder(requirement, "path");
+    const queryCoder = new ParametersTypeCoder(requirement, "query");
+    const headerCoder = new ParametersTypeCoder(requirement, "header");
+
+    expect(format(`type TestType =${pathCoder.write({})}`)).toMatchSnapshot(
+      "path"
+    );
+    expect(format(`type TestType =${queryCoder.write({})}`)).toMatchSnapshot(
+      "query"
+    );
+    expect(format(`type TestType =${headerCoder.write({})}`)).toMatchSnapshot(
+      "header"
+    );
+  });
+
   it("generates type never when there is no match", () => {
     const requirement = new Requirement([
       { name: "id", in: "path", schema: { type: "string" }, required: true },

--- a/test/typescript-generator/requirement.test.js
+++ b/test/typescript-generator/requirement.test.js
@@ -115,4 +115,18 @@ describe("a Requirement", () => {
       "b: bar 2",
     ]);
   });
+
+  it("provides a find(fn) method", () => {
+    const requirement = new Requirement({
+      a: "foo",
+      b: "bar",
+    });
+
+    const result = requirement.find(
+      // eslint-disable-next-line jest/no-conditional-in-test
+      (subRequirement, key) => key === "b" && subRequirement.data === "bar"
+    );
+
+    expect(result).toStrictEqual(requirement.get("b"));
+  });
 });


### PR DESCRIPTION
Add support for OpenAPI 2. This is hacky. More unit tests are needed. I should look at the actual spec version rather than duck type. 

Maybe create subclasses of each Coder for OpenAPI 2. That implies a factory for creating coders instead of calling their constructors directly. That may be a better design in the long run, but I don't think I want to deal with that right now. 

- add a shortcut for generating (testing) pet store v2
- support for OAS2 parameter, where there is not a separate schema object
- generate a default response for an OAS2 operation
- refactoring caused whitespace changes in the snapshot
- generate the response type for OAS2
- move the code to copy response-builder-factory.ts into generate()
- move copying response-builder-factory.ts into repository.js
- refactoring changed whitespace in the snapshot
- support OpenAPI2 when building the response object
- don't start the server when testing via yarn go:petstore
- support the request body in OpenAPI 2
- consistently set request properties to 'never' when they should not be there
