### PR TITLE
change the way JSONSchemaFaker is imported so it works with CJS

### DIFF
--- a/.changeset/short-plums-grin.md
+++ b/.changeset/short-plums-grin.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+change the way JSONSchemaFaker is imported to avoid CJS -> ESM issues

--- a/src/server/response-builder.js
+++ b/src/server/response-builder.js
@@ -1,4 +1,4 @@
-import { JSONSchemaFaker } from "json-schema-faker";
+import JSONSchemaFaker from "json-schema-faker";
 
 JSONSchemaFaker.option("useExamplesValue", true);
 


### PR DESCRIPTION
This stuff gives me a headache. The default export from JSONSchemaFaker is marked deprecated. [Long story](https://github.com/json-schema-faker/json-schema-faker/issues/712). 

I tried to switch to the new, non-deprecated named export, and that worked fine until I tried to install Counterfact and use it rather than run it directly from the package. 

```
npx counterfact@latest https://petstore3.swagger.io/api/v3/openapi.json api --open

file:///Users/pmcelhaney/.npm/_npx/e8d1761dc3fb6aab/node_modules/counterfact/src/server/response-builder.js:1
import { JSONSchemaFaker } from "json-schema-faker";
         ^^^^^^^^^^^^^^^
SyntaxError: Named export 'JSONSchemaFaker' not found. The requested module 'json-schema-faker' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'json-schema-faker';
const { JSONSchemaFaker } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:127:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:193:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:61:12)
```

When I follow the recommendation in that error message it says `JSONSchemaFaker` is undefined.

If I follow that recommendation but change the first line to `import * as pkg` it seems to work but I don't know if it's going to work in every case. Going back to what I know for sure works. 