### PR TITLE
work around what appears to be a Koa bug

### DIFF
--- a/src/server/start.js
+++ b/src/server/start.js
@@ -106,14 +106,15 @@ export async function start({
     })
   );
 
-  app.use((ctx, next) => {
+  app.use(async (ctx, next) => {
     if (ctx.URL.pathname === "/counterfact") {
       ctx.redirect("/counterfact/");
 
       return;
     }
 
-    next();
+    // eslint-disable-next-line node/callback-return
+    await next();
   });
 
   app.use(


### PR DESCRIPTION
It seems Koa doesn't wait for the response from `next()` now unless it's explicitly awaited. It makes sense. Maybe that's not a Koa bug. I'm not sure how it was working before.