### PR TITLE
fix an issue where ts-node was not being used

### DIFF
--- a/.changeset/grumpy-peaches-repair.md
+++ b/.changeset/grumpy-peaches-repair.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+fix an issue where ts-node was not being used, which basically broke everything

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,6 +1,7 @@
 "use strict";
 
 const rules = {
+  "n/shebang": "off",
   "putout/putout": "off",
   "import/prefer-default-export": "off",
   "@typescript-eslint/naming-convention": "off",

--- a/bin/counterfact.js
+++ b/bin/counterfact.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env ts-node
 
 import nodePath from "node:path";
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "go:petstore": "yarn counterfact https://petstore3.swagger.io/api/v3/openapi.json out",
     "go:petstore2": "yarn counterfact  https://petstore.swagger.io/v2/swagger.json out",
     "go:example": "yarn counterfact ./openapi-example.yaml out --open",
-    "counterfact": "ts-node --esm --transpileOnly ./bin/counterfact.js"
+    "counterfact": "./bin/counterfact.js"
   },
   "devDependencies": {
     "@changesets/cli": "2.26.2",


### PR DESCRIPTION
reverts a change that happened by mistake because I was trying to comply with the "n/shebang" eslint rule