### PR TITLE
fix(typescript-generator): remove useless path from import statements

### DIFF
--- a/src/typescript-generator/script.js
+++ b/src/typescript-generator/script.js
@@ -154,7 +154,7 @@ export class Script {
       ([name, { script, isType, isDefault }]) =>
         `import${isType ? " type" : ""} ${
           isDefault ? name : `{ ${name} }`
-        } from "./${nodePath.relative(
+        } from "${nodePath.relative(
           nodePath.dirname(this.path),
           script.path.replace(/\.ts$/u, ".js")
         )}";`


### PR DESCRIPTION
The Typescript Generator is adding a useless path in every import statement. This removes the `./` in front of each path.