### PR TITLE
fix(typescript-generator): remove useless path from import statements

### DIFF
--- a/.changeset/new-queens-study.md
+++ b/.changeset/new-queens-study.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Update TS generator to avoid useless paths in imports

--- a/src/typescript-generator/script.js
+++ b/src/typescript-generator/script.js
@@ -154,7 +154,7 @@ export class Script {
       ([name, { script, isType, isDefault }]) =>
         `import${isType ? " type" : ""} ${
           isDefault ? name : `{ ${name} }`
-        } from "./${nodePath.relative(
+        } from "${nodePath.relative(
           nodePath.dirname(this.path),
           script.path.replace(/\.ts$/u, ".js")
         )}";`

--- a/test/typescript-generator/script.test.js
+++ b/test/typescript-generator/script.test.js
@@ -93,9 +93,9 @@ describe("a Script", () => {
     script.importDefault(coder);
 
     expect(script.importStatements()).toStrictEqual([
-      'import { Account0 } from "./export-from-me.js";',
-      'import type { Account1 } from "./export-from-me.js";',
-      'import Account2 from "./export-from-me.js";',
+      'import { Account0 } from "export-from-me.js";',
+      'import type { Account1 } from "export-from-me.js";',
+      'import Account2 from "export-from-me.js";',
     ]);
   });
 


### PR DESCRIPTION
Updates the TypeScript generator not to prepend the useless path of `./` in front of all the imports. This is causing linter errors when using mocks in live projects.