### PR TITLE
TypeScript Generator relative path fix

### DIFF
--- a/.changeset/fast-planes-sell.md
+++ b/.changeset/fast-planes-sell.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Fix typescript-generator importStatements logic for relative paths

--- a/src/typescript-generator/script.js
+++ b/src/typescript-generator/script.js
@@ -161,18 +161,18 @@ export class Script {
   }
 
   importStatements() {
-    return Array.from(
-      this.imports,
-      ([name, { script, isType, isDefault }]) =>
-        `import${isType ? " type" : ""} ${
-          isDefault ? name : `{ ${name} }`
-        } from "./${nodePath
-          .relative(
-            nodePath.dirname(this.path).replaceAll("\\", "/"),
-            script.path.replace(/\.ts$/u, ".js")
-          )
-          .replaceAll("\\", "/")}";`
-    );
+    return Array.from(this.imports, ([name, { script, isType, isDefault }]) => {
+      const resolvedPath = nodePath
+        .relative(
+          nodePath.dirname(this.path).replaceAll("\\", "/"),
+          script.path.replace(/\.ts$/u, ".js")
+        )
+        .replaceAll("\\", "/");
+
+      return `import${isType ? " type" : ""} ${
+        isDefault ? name : `{ ${name} }`
+      } from "${resolvedPath.includes("../") ? "" : "./"}${resolvedPath}";`;
+    });
   }
 
   exportStatements() {

--- a/test/typescript-generator/script.test.js
+++ b/test/typescript-generator/script.test.js
@@ -99,6 +99,39 @@ describe("a Script", () => {
     ]);
   });
 
+  it("handles relative import statements", () => {
+    const repository = new Repository("/base/path");
+
+    class CoderThatWantsToImportAccount extends Coder {
+      *names() {
+        let index = 0;
+
+        while (true) {
+          yield `Account${index}`;
+          index += 1;
+        }
+      }
+
+      modulePath() {
+        return "../../export-from-me.ts";
+      }
+    }
+
+    const coder = new CoderThatWantsToImportAccount({});
+
+    const script = repository.get("import-to-me.ts");
+
+    script.import(coder);
+    script.importType(coder);
+    script.importDefault(coder);
+
+    expect(script.importStatements()).toStrictEqual([
+      'import { Account0 } from "../../export-from-me.js";',
+      'import type { Account1 } from "../../export-from-me.js";',
+      'import Account2 from "../../export-from-me.js";',
+    ]);
+  });
+
   it("creates export statements", async () => {
     const repository = new Repository("/base/path");
 


### PR DESCRIPTION
Fixes the `importStatements` logic to avoid lint errors with relative paths.