### PR TITLE
make paths case-insensitive

### DIFF
--- a/.changeset/eight-papayas-melt.md
+++ b/.changeset/eight-papayas-melt.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+make paths in URLs case-insensitive (http://localhost:3100/FOO is the same as http://localhost:3100/foo)

--- a/src/server/registry.js
+++ b/src/server/registry.js
@@ -84,9 +84,13 @@ export class Registry {
     const matchedParts = [""];
 
     for (const segment of url.split("/").slice(1)) {
-      if (node.children[segment]) {
-        node = node.children[segment];
-        matchedParts.push(segment);
+      const matchingChild = Object.keys(node.children).find(
+        (candidate) => candidate.toLowerCase() === segment.toLowerCase(),
+      );
+
+      if (matchingChild) {
+        node = node.children[matchingChild];
+        matchedParts.push(matchingChild);
       } else {
         const dynamicSegment = Object.keys(node.children).find(
           (ds) => ds.startsWith("{") && ds.endsWith("}"),

--- a/test/server/registry.test.js
+++ b/test/server/registry.test.js
@@ -103,6 +103,24 @@ describe("a registry", () => {
     });
   });
 
+  it("matches an endpoint where the case does not match", () => {
+    const registry = new Registry();
+
+    registry.add("/{organization}/users/{username}/friends/{page}", {
+      GET({ path }) {
+        return {
+          body: `page ${path.page} of ${path.username}'s friends in ${path.organization}`,
+        };
+      },
+    });
+
+    expect(
+      registry.endpoint("GET", "/Acme/users/alice/Friends/2")({}),
+    ).toStrictEqual({
+      body: "page 2 of alice's friends in Acme",
+    });
+  });
+
   it("lists all of the routes", () => {
     const registry = new Registry();
 


### PR DESCRIPTION
If APIs are deployed on Windows, they may not be picky about URLs have the correct case. This change makes Counterfact work the same way. `GET /foo` and `GET /FOO` are the same. 

At some point, we might want to add a setting so that "strict" mode can be enabled. For now, I think the majority of people will either benefit from the change or won't notice any difference. 

See https://github.com/pmcelhaney/counterfact/discussions/537