### PR TITLE
no patch package after install

### DIFF
--- a/.changeset/slow-kangaroos-move.md
+++ b/.changeset/slow-kangaroos-move.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+remove postinstall script that was preventing counterfact from installing

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,14 +35,14 @@ jobs:
           key: ${{ runner.os }}-${{ steps.node-version.outputs.version }}-${{ hashFiles('**/yarn.lock') }}
       - name: Install Packages
         run: yarn install --frozen-lockfile --network-timeout 100000
+      - name: Patch packages
+        run: yarn patch-package
       - name: ESlint
         run: yarn eslint -f github-annotations .
       - name: TypeScript
         run: yarn tsc --noEmit
       - name: Unit Tests
         timeout-minutes: 2
-        env:
-          DEBUG: "counterfact:*"
         run: yarn test --runInBand --forceExit --verbose --no-watchman
       - name: Black Box Tests
         timeout-minutes: 2

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 > TL;DR: Do you have Node 16+ installed? Run this command.
 >
 > ```sh copy
-> npx counterfact@0.25.0 https://petstore3.swagger.io/api/v3/openapi.yaml api --open
+> npx counterfact@latest https://petstore3.swagger.io/api/v3/openapi.yaml api --open
 > ```
 
 ## High code, low effort, mock REST APIs
@@ -73,7 +73,7 @@ The only prerequisite is Node 16+.
 For example, run the following command to generate code for the [Swagger Petstore](https://petstore.swagger.io/).
 
 ```sh
-  npx counterfact@0.25.0 https://petstore3.swagger.io/api/v3/openapi.yaml api --open
+  npx counterfact@latest https://petstore3.swagger.io/api/v3/openapi.yaml api --open
 ```
 
 That command generates and starts a TypeScript implementation of the Swagger Petstore which returns random, valid responses, outputting code to the "api" directory, and opens a web browser with tools to interact with the API. You can replace the Petstore URL with a link to your own spec, either a URL or a local file. OpenAPI / Swagger versions 2 and 3 are supported.
@@ -86,7 +86,7 @@ That command generates and starts a TypeScript implementation of the Swagger Pet
 Again, using the [Swagger Petstore](https://petstore.swagger.io/) as an example:
 
 ```sh
-  npx counterfact@0.25.0 https://petstore3.swagger.io/api/v3/openapi.yaml api
+  npx counterfact@latest https://petstore3.swagger.io/api/v3/openapi.yaml api
 ```
 
 Counterfact reads the components from the [spec](https://petstore3.swagger.io/api/v3/openapi.yaml) and converts them into equivalent TypeScript types. For example, here's `./api/components/Pet.ts`:
@@ -115,7 +115,7 @@ These types are used internally by Counterfact. You can also use them in your cl
 Add the `--proxy-url <url>` flag to point to the location of a real server.
 
 ```sh
-  npx counterfact@0.25.0 ./path/to/your/spec api --proxy-url https://your-server.example.com/
+  npx counterfact@latest ./path/to/your/spec api --proxy-url https://your-server.example.com/
 ```
 
 All requests will be proxied to the real server, e.g. a request to `http://localhost:3100/hello-world` will be routed to `https://your-server.example.com/`. To toggle between having Counterfact handle requests and having it hand them off to the real server, type `.proxy on` / `.proxy off` in the REPL.

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "go:petstore": "yarn build && yarn counterfact https://petstore3.swagger.io/api/v3/openapi.json out",
     "go:petstore2": "yarn build && yarn counterfact  https://petstore.swagger.io/v2/swagger.json out",
     "go:example": "yarn build && yarn counterfact ./openapi-example.yaml out",
-    "counterfact": "./bin/counterfact.js",
-    "postinstall": "patch-package"
+    "counterfact": "./bin/counterfact.js"
   },
   "devDependencies": {
     "@changesets/cli": "2.26.2",


### PR DESCRIPTION
Version 0.26.0 was not working because it's trying to run patch-package after install, and the command patch-package is "not found". The only package that's being patched is a dev dependency so it's not needed anyway. 
