### PR TITLE
fix(server): fixes Custom headers not being correctly added from the response builder #593

### DIFF
--- a/.changeset/famous-humans-juggle.md
+++ b/.changeset/famous-humans-juggle.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Fixes issue #593 where custom response headers were not being set

--- a/src/server/koa-middleware.ts
+++ b/src/server/koa-middleware.ts
@@ -61,6 +61,11 @@ export function koaMiddleware(
 
     /* eslint-disable require-atomic-updates */
     ctx.body = response.body;
+    if (response.headers) {
+      for (const [key, value] of Object.entries(response.headers)) {
+        ctx.set(key, value.toString());
+      }
+    }
     ctx.status = response.status ?? HTTP_STATUS_CODE_OK;
     /* eslint-enable require-atomic-updates */
 

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -60,6 +60,7 @@ type CounterfactResponseObject =
         body: unknown;
         type: MediaType;
       }[];
+      contentType?: string;
       headers?: { [key: string]: number | string };
       status?: number;
     };
@@ -67,6 +68,17 @@ type CounterfactResponseObject =
 type CounterfactResponse =
   | CounterfactResponseObject
   | Promise<CounterfactResponseObject>;
+
+interface NormalizedCounterfactResponseObject {
+  body?: string;
+  content?: {
+    body: unknown;
+    type: MediaType;
+  }[];
+  contentType?: string;
+  headers?: { [key: string]: number | string };
+  status?: number;
+}
 
 function castParameters(
   parameters: { [key: string]: number | string },
@@ -245,5 +257,6 @@ export type {
   CounterfactResponseObject,
   HttpMethods,
   Module,
+  NormalizedCounterfactResponseObject,
   RequestDataWithBody,
 };


### PR DESCRIPTION
fix #593

Corrects the logic in `koa-middleware.js` to properly add any custom response headers. Also fleshes out some of the types in `dispatcher` to be more explicit about the response types coming to the `koa-middleware`.