### PR TITLE
fix root context not shared

### DIFF
--- a/.changeset/afraid-bugs-sniff.md
+++ b/.changeset/afraid-bugs-sniff.md
@@ -1,0 +1,13 @@
+---
+"counterfact": minor
+---
+
+Fixed an issue where the context object wasn't working as expected.
+
+BREAKING CHANGE:
+
+- the main $.context.ts file needs an extra line: `export type ContextType = typeof Context;`
+- $.context.ts files below the root need to change to `export type { ContextType } from "../$.context";`
+- if you modified any of the $.context.ts files below the root, treat the first bullet applies
+
+When you run Counterfact, it will try to make these changes for you, so ideally you won't have to worry about it.

--- a/bin/counterfact.js
+++ b/bin/counterfact.js
@@ -6,6 +6,7 @@ import { program } from "commander";
 import createDebug from "debug";
 import open from "open";
 
+import { migrate } from "../dist/src/migrations/0.27.js";
 import { startRepl } from "../dist/src/server/repl.js";
 import { start } from "../dist/src/server/start.js";
 import { generate } from "../dist/src/typescript-generator/generate.js";
@@ -29,6 +30,10 @@ async function main(source, destination) {
   const destinationPath = nodePath
     .join(process.cwd(), destination)
     .replaceAll("\\", "/");
+
+  debug("migrating code from before 0.27.0");
+  migrate(destinationPath);
+  debug("done with migration");
 
   debug('generating code at "%s"', destinationPath);
 

--- a/src/migrations/0.27.js
+++ b/src/migrations/0.27.js
@@ -1,4 +1,10 @@
-import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 
 function processFile(filePath) {
@@ -24,6 +30,10 @@ function processFile(filePath) {
 }
 
 function migrateContextFiles(path) {
+  if (!existsSync(path)) {
+    return;
+  }
+
   const items = readdirSync(path);
 
   for (const item of items) {
@@ -41,5 +51,9 @@ function migrateContextFiles(path) {
 }
 
 export function migrate(rootPath) {
+  if (!existsSync(rootPath)) {
+    return;
+  }
+
   migrateContextFiles(join(rootPath, "paths"));
 }

--- a/src/migrations/0.27.js
+++ b/src/migrations/0.27.js
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function processFile(filePath) {
+  const content = readFileSync(filePath, "utf8");
+
+  if (
+    content.includes("export type ContextType =") ||
+    content.includes("export type { ContextType }")
+  ) {
+    return;
+  }
+
+  if (content.includes("export default new Context")) {
+    writeFileSync(filePath, "export type ContextType = typeof Context;\n", {
+      flag: "a",
+    });
+  } else {
+    writeFileSync(
+      filePath,
+      'export type { ContextType } from "../$.context";\n',
+    );
+  }
+}
+
+function migrateContextFiles(path) {
+  const items = readdirSync(path);
+
+  for (const item of items) {
+    const itemPath = join(path, item);
+    const stats = statSync(itemPath);
+
+    if (stats.isDirectory()) {
+      migrateContextFiles(itemPath);
+    }
+
+    if (stats.isFile() && item === "$.context.ts") {
+      processFile(itemPath);
+    }
+  }
+}
+
+export function migrate(rootPath) {
+  migrateContextFiles(join(rootPath, "paths"));
+}

--- a/src/server/context-registry.ts
+++ b/src/server/context-registry.ts
@@ -15,7 +15,11 @@ export class ContextRegistry {
 
   public add(path: string, context?: Context): void {
     if (context === undefined) {
-      throw new Error("context cannot be undefined");
+      // If $.context.ts exists but only exports a type, then the context object will be undefined here.
+      // This should be handled upstream, so that add() is not called in the first place.
+      // But module-loader.ts needs to be refactored a bit using type guards and the is operator
+      // before that can be done cleanly.
+      return;
     }
 
     this.entries.set(path, context);

--- a/src/typescript-generator/context-coder.js
+++ b/src/typescript-generator/context-coder.js
@@ -36,18 +36,8 @@ class Context {
 `;
   }
 
-  write(script) {
-    if (script.path === "paths/$.context.ts") {
-      return "new Context()";
-    }
-
-    const parentPath = nodePath
-      .normalize(nodePath.join(script.path, "../../$.context.ts"))
-      .replaceAll("\\", "/");
-
-    script.repository.get(parentPath).exportDefault(this);
-
-    return { raw: 'export { default } from "../$.context.mjs"' };
+  write() {
+    return "new Context()";
   }
 
   modulePath() {

--- a/src/typescript-generator/context-type-coder.js
+++ b/src/typescript-generator/context-type-coder.js
@@ -1,0 +1,40 @@
+import nodePath from "node:path";
+
+import { Coder } from "./coder.js";
+
+export class ContextTypeCoder extends Coder {
+  constructor(requirement, isRoot) {
+    super(requirement);
+    this.isRoot = isRoot;
+  }
+
+  pathString() {
+    return this.requirement.url
+      .split("/")
+      .at(-2)
+      .replaceAll("~1", "/")
+      .replaceAll("~0", "~");
+  }
+
+  get id() {
+    return "ContextTypeCoder";
+  }
+
+  names() {
+    return super.names("ContextType");
+  }
+
+  write(script) {
+    if (script.path === "paths/$.context.ts") {
+      return "typeof Context";
+    }
+
+    return { raw: 'export type { ContextType } from "../$.context"' };
+  }
+
+  modulePath() {
+    return nodePath
+      .join("paths", nodePath.dirname(this.pathString()), "$.context.ts")
+      .replaceAll("\\", "/");
+  }
+}

--- a/src/typescript-generator/generate.js
+++ b/src/typescript-generator/generate.js
@@ -5,6 +5,7 @@ import nodePath from "node:path";
 import createDebug from "debug";
 
 import { ensureDirectoryExists } from "../util/ensure-directory-exists.js";
+import { ContextCoder } from "./context-coder.js";
 import { OperationCoder } from "./operation-coder.js";
 import { Repository } from "./repository.js";
 import { Specification } from "./specification.js";
@@ -65,6 +66,8 @@ export async function generate(
       repository.get(`paths${key}.ts`).export(new OperationCoder(operation));
     });
   });
+
+  repository.get("paths/$.context.ts").exportDefault(new ContextCoder(paths));
 
   debug("telling the repository to write the files to %s", destination);
 

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -1,7 +1,7 @@
 import nodePath from "node:path";
 
 import { Coder } from "./coder.js";
-import { ContextCoder } from "./context-coder.js";
+import { ContextTypeCoder } from "./context-type-coder.js";
 import { ParametersTypeCoder } from "./parameters-type-coder.js";
 import { ResponseTypeCoder } from "./response-type-coder.js";
 import { SchemaTypeCoder } from "./schema-type-coder.js";
@@ -68,8 +68,8 @@ export class OperationTypeCoder extends Coder {
   }
 
   write(script) {
-    const contextImportName = script.importDefault(
-      new ContextCoder(this.requirement),
+    const contextTypeImportName = script.importType(
+      new ContextTypeCoder(this.requirement),
     );
 
     const parameters = this.requirement.get("parameters");
@@ -109,7 +109,7 @@ export class OperationTypeCoder extends Coder {
 
     const proxyType = "(url: string) => { proxyUrl: string }";
 
-    return `({ query, path, header, body, context, proxy }: { query: ${queryType}, path: ${pathType}, header: ${headerType}, body: ${bodyType}, context: typeof ${contextImportName}, response: ${responseType}, proxy: ${proxyType} }) => ${this.responseTypes(
+    return `({ query, path, header, body, context, proxy }: { query: ${queryType}, path: ${pathType}, header: ${headerType}, body: ${bodyType}, context: ${contextTypeImportName}, response: ${responseType}, proxy: ${proxyType} }) => ${this.responseTypes(
       script,
     )} | { status: 415, contentType: "text/plain", body: string } | void`;
   }

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -188,4 +188,36 @@ describe("a module loader", () => {
       expect(contextRegistry.find("/some/other/path")).toBe("main");
     });
   });
+
+  it("provides the parent context if the locale $.context.ts doesn't export a default", async () => {
+    const files: { [key: string]: string } = {
+      "$.context.mjs": "export default { value: 0 }",
+      "hello/$.context.mjs": "export default { value: 100 }",
+    };
+
+    await withTemporaryFiles(files, async (basePath: string) => {
+      const registry: Registry = new Registry();
+
+      const contextRegistry: ContextRegistry = new ContextRegistry();
+
+      const loader: ModuleLoader = new ModuleLoader(
+        basePath,
+        registry,
+        contextRegistry,
+      );
+
+      await loader.load();
+
+      const rootContext = contextRegistry.find("/");
+      const helloContext = contextRegistry.find("/hello");
+
+      rootContext.value = 1;
+      helloContext.value = 101;
+
+      expect(contextRegistry.find("/").value).toBe(1);
+      expect(contextRegistry.find("/other").value).toBe(1);
+      expect(contextRegistry.find("/hello").value).toBe(101);
+      expect(contextRegistry.find("/hello/world").value).toBe(101);
+    });
+  });
 });

--- a/test/typescript-generator/__snapshots__/generate.test.ts.snap
+++ b/test/typescript-generator/__snapshots__/generate.test.ts.snap
@@ -47,13 +47,13 @@ Map {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet/post@[object Object]:true" => "HTTP_POST",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet/put@[object Object]:true" => "HTTP_PUT",
-            "ContextCoder@paths/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -90,7 +90,7 @@ Map {
             },
             "HTTP_PUT" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -145,13 +145,14 @@ Map {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
                   "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
                   "Context" => Object {
@@ -175,6 +176,17 @@ class Context {
                     "isDefault": true,
                     "isType": false,
                     "name": "Context",
+                    "promise": Promise {},
+                    "typeDeclaration": "",
+                  },
+                  "ContextType" => Object {
+                    "beforeExport": "",
+                    "code": "typeof Context",
+                    "done": true,
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -302,13 +314,13 @@ class Context {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet/post@[object Object]:true" => "HTTP_POST",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet/put@[object Object]:true" => "HTTP_PUT",
-            "ContextCoder@paths/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -345,7 +357,7 @@ class Context {
             },
             "HTTP_PUT" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -400,13 +412,14 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
                   "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
                   "Context" => Object {
@@ -430,6 +443,17 @@ class Context {
                     "isDefault": true,
                     "isType": false,
                     "name": "Context",
+                    "promise": Promise {},
+                    "typeDeclaration": "",
+                  },
+                  "ContextType" => Object {
+                    "beforeExport": "",
+                    "code": "typeof Context",
+                    "done": true,
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -561,13 +585,13 @@ class Context {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet/post@[object Object]:true" => "HTTP_POST",
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet/put@[object Object]:true" => "HTTP_PUT",
-      "ContextCoder@paths/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
     },
     "exports": Map {
       "HTTP_POST" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -604,7 +628,7 @@ class Context {
       },
       "HTTP_PUT" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Pet, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -659,13 +683,14 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
             "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
             "Context" => Object {
@@ -689,6 +714,17 @@ class Context {
               "isDefault": true,
               "isType": false,
               "name": "Context",
+              "promise": Promise {},
+              "typeDeclaration": "",
+            },
+            "ContextType" => Object {
+              "beforeExport": "",
+              "code": "typeof Context",
+              "done": true,
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -836,13 +872,13 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByStatus/get@[object Object]:true" => "HTTP_GET",
-            "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"status?\\": \\"available\\" | \\"pending\\" | \\"sold\\"}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"status?\\": \\"available\\" | \\"pending\\" | \\"sold\\"}, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -885,38 +921,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -1047,13 +1070,13 @@ class Context {
   "path-types/pet/findByStatus.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByStatus/get@[object Object]:true" => "HTTP_GET",
-      "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: {\\"status?\\": \\"available\\" | \\"pending\\" | \\"sold\\"}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: {\\"status?\\": \\"available\\" | \\"pending\\" | \\"sold\\"}, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -1096,38 +1119,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -1275,13 +1285,13 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByTags/get@[object Object]:true" => "HTTP_GET",
-            "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"tags?\\": Array<string>}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"tags?\\": Array<string>}, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -1324,38 +1334,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -1486,13 +1483,13 @@ class Context {
   "path-types/pet/findByTags.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByTags/get@[object Object]:true" => "HTTP_GET",
-      "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: {\\"tags?\\": Array<string>}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: {\\"tags?\\": Array<string>}, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -1535,38 +1532,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -1742,13 +1726,13 @@ class Context {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post@[object Object]:true" => "HTTP_POST",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -1791,7 +1775,7 @@ class Context {
             },
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 405: {
           headers: {};
           content: {};
@@ -1809,7 +1793,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -1833,38 +1817,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -1993,13 +1964,13 @@ class Context {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post@[object Object]:true" => "HTTP_POST",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -2042,7 +2013,7 @@ class Context {
             },
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 405: {
           headers: {};
           content: {};
@@ -2060,7 +2031,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -2084,38 +2055,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -2244,13 +2202,13 @@ class Context {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post@[object Object]:true" => "HTTP_POST",
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -2293,7 +2251,7 @@ class Context {
             },
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 405: {
           headers: {};
           content: {};
@@ -2311,7 +2269,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -2335,38 +2293,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -2499,13 +2444,13 @@ class Context {
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get@[object Object]:true" => "HTTP_GET",
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post@[object Object]:true" => "HTTP_POST",
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete@[object Object]:true" => "HTTP_DELETE",
-      "ContextCoder@paths/pet/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/pet/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/Pet.ts:true:false" => "Pet",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -2548,7 +2493,7 @@ class Context {
       },
       "HTTP_POST" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: {\\"name?\\": number, \\"status?\\": string}, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 405: {
           headers: {};
           content: {};
@@ -2566,7 +2511,7 @@ class Context {
       },
       "HTTP_DELETE" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"petId\\": string}, header: {\\"api_key?\\": string}, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -2590,38 +2535,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -2769,13 +2701,13 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}~1uploadImage/post@[object Object]:true" => "HTTP_POST",
-            "ContextCoder@paths/pet/{petId}/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/pet/{petId}/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/ApiResponse.ts:true:false" => "ApiResponse",
           },
           "exports": Map {
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"additionalMetadata?\\": number}, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"additionalMetadata?\\": number}, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -2805,38 +2737,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/{petId}/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -2902,13 +2821,13 @@ class Context {
   "path-types/pet/{petId}/uploadImage.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}~1uploadImage/post@[object Object]:true" => "HTTP_POST",
-      "ContextCoder@paths/pet/{petId}/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/pet/{petId}/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/ApiResponse.ts:true:false" => "ApiResponse",
     },
     "exports": Map {
       "HTTP_POST" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: {\\"additionalMetadata?\\": number}, path: {\\"petId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: {\\"additionalMetadata?\\": number}, path: {\\"petId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -2938,38 +2857,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/{petId}/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -3052,12 +2958,12 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1store~1inventory/get@[object Object]:true" => "HTTP_GET",
-            "ContextCoder@paths/store/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/store/$.context.ts:true:false" => "ContextType",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3087,38 +2993,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -3153,12 +3046,12 @@ class Context {
   "path-types/store/inventory.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1store~1inventory/get@[object Object]:true" => "HTTP_GET",
-      "ContextCoder@paths/store/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/store/$.context.ts:true:false" => "ContextType",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3188,38 +3081,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -3271,13 +3151,13 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order/post@[object Object]:true" => "HTTP_POST",
-            "ContextCoder@paths/store/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/store/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Order.ts:true:false" => "Order",
           },
           "exports": Map {
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Order, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3313,38 +3193,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -3410,13 +3277,13 @@ class Context {
   "path-types/store/order.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order/post@[object Object]:true" => "HTTP_POST",
-      "ContextCoder@paths/store/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/store/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/Order.ts:true:false" => "Order",
     },
     "exports": Map {
       "HTTP_POST" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Order, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Order, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3452,38 +3319,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -3580,13 +3434,13 @@ class Context {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/store/order/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/store/order/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Order.ts:true:false" => "Order",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3629,7 +3483,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -3659,38 +3513,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/order/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -3753,13 +3594,13 @@ class Context {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/store/order/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/store/order/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/Order.ts:true:false" => "Order",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3802,7 +3643,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -3832,38 +3673,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/order/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -3930,13 +3758,13 @@ class Context {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/get@[object Object]:true" => "HTTP_GET",
       "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/delete@[object Object]:true" => "HTTP_DELETE",
-      "ContextCoder@paths/store/order/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/store/order/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/Order.ts:true:false" => "Order",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -3979,7 +3807,7 @@ class Context {
       },
       "HTTP_DELETE" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"orderId\\": number}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -4009,38 +3837,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/order/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -4123,13 +3938,13 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user/post@[object Object]:true" => "HTTP_POST",
-            "ContextCoder@paths/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
           },
           "exports": Map {
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: User, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {
@@ -4166,13 +3981,14 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
                   "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
                   "Context" => Object {
@@ -4196,6 +4012,17 @@ class Context {
                     "isDefault": true,
                     "isType": false,
                     "name": "Context",
+                    "promise": Promise {},
+                    "typeDeclaration": "",
+                  },
+                  "ContextType" => Object {
+                    "beforeExport": "",
+                    "code": "typeof Context",
+                    "done": true,
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -4261,13 +4088,13 @@ class Context {
   "path-types/user.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1user/post@[object Object]:true" => "HTTP_POST",
-      "ContextCoder@paths/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
     },
     "exports": Map {
       "HTTP_POST" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: User, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {
@@ -4304,13 +4131,14 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
             "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
             "Context" => Object {
@@ -4334,6 +4162,17 @@ class Context {
               "isDefault": true,
               "isType": false,
               "name": "Context",
+              "promise": Promise {},
+              "typeDeclaration": "",
+            },
+            "ContextType" => Object {
+              "beforeExport": "",
+              "code": "typeof Context",
+              "done": true,
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -4416,13 +4255,13 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1createWithList/post@[object Object]:true" => "HTTP_POST",
-            "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
           },
           "exports": Map {
             "HTTP_POST" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Array<User>, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -4465,38 +4304,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -4562,13 +4388,13 @@ class Context {
   "path-types/user/createWithList.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1user~1createWithList/post@[object Object]:true" => "HTTP_POST",
-      "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
     },
     "exports": Map {
       "HTTP_POST" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Array<User>, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: Array<User>, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -4611,38 +4437,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -4725,12 +4538,12 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1login/get@[object Object]:true" => "HTTP_GET",
-            "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: {\\"username?\\": string, \\"password?\\": string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: {\\"username?\\": string, \\"password?\\": string}, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {
 \\"X-Rate-Limit\\": { schema: number},
@@ -4776,38 +4589,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -4842,12 +4642,12 @@ class Context {
   "path-types/user/login.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1user~1login/get@[object Object]:true" => "HTTP_GET",
-      "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: {\\"username?\\": string, \\"password?\\": string}, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: {\\"username?\\": string, \\"password?\\": string}, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {
 \\"X-Rate-Limit\\": { schema: number},
@@ -4893,38 +4693,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -4974,12 +4761,12 @@ class Context {
         "script": Script {
           "cache": Map {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1logout/get@[object Object]:true" => "HTTP_GET",
-            "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
@@ -5003,38 +4790,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -5069,12 +4843,12 @@ class Context {
   "path-types/user/logout.types.ts" => Script {
     "cache": Map {
       "OperationTypeCoder@./petstore.yaml#/paths/~1user~1logout/get@[object Object]:true" => "HTTP_GET",
-      "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: never, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
@@ -5098,38 +4872,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -5209,13 +4970,13 @@ class Context {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put@[object Object]:true" => "HTTP_PUT",
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -5258,7 +5019,7 @@ class Context {
             },
             "HTTP_PUT" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
@@ -5276,7 +5037,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -5306,38 +5067,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -5401,13 +5149,13 @@ class Context {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put@[object Object]:true" => "HTTP_PUT",
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -5450,7 +5198,7 @@ class Context {
             },
             "HTTP_PUT" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
@@ -5468,7 +5216,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -5498,38 +5246,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -5593,13 +5328,13 @@ class Context {
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get@[object Object]:true" => "HTTP_GET",
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put@[object Object]:true" => "HTTP_PUT",
             "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete@[object Object]:true" => "HTTP_DELETE",
-            "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+            "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
             "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
           },
           "exports": Map {
             "HTTP_GET" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -5642,7 +5377,7 @@ class Context {
             },
             "HTTP_PUT" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
@@ -5660,7 +5395,7 @@ class Context {
             },
             "HTTP_DELETE" => Object {
               "beforeExport": "",
-              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+              "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -5690,38 +5425,25 @@ class Context {
             },
           },
           "imports": Map {
-            "Context" => Object {
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+            "ContextType" => Object {
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "script": Script {
                 "cache": Map {
-                  "default" => "Context",
+                  "ContextTypeCoder@[object Object]:true" => "ContextType",
                 },
                 "exports": Map {
-                  "Context" => Object {
-                    "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+                  "ContextType" => Object {
+                    "beforeExport": "",
                     "code": Object {
-                      "raw": "export { default } from \\"../$.context.mjs\\"",
+                      "raw": "export type { ContextType } from \\"../$.context\\"",
                     },
                     "done": true,
-                    "id": "ContextCoder",
-                    "isDefault": true,
-                    "isType": false,
-                    "name": "Context",
+                    "id": "ContextTypeCoder",
+                    "isDefault": false,
+                    "isType": true,
+                    "name": "ContextType",
                     "promise": Promise {},
                     "typeDeclaration": "",
                   },
@@ -5789,13 +5511,13 @@ class Context {
       "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get@[object Object]:true" => "HTTP_GET",
       "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put@[object Object]:true" => "HTTP_PUT",
       "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete@[object Object]:true" => "HTTP_DELETE",
-      "ContextCoder@paths/user/$.context.ts:false:true" => "Context",
+      "ContextTypeCoder@paths/user/$.context.ts:true:false" => "ContextType",
       "SchemaTypeCoder@undefined@components/User.ts:true:false" => "User",
     },
     "exports": Map {
       "HTTP_GET" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 200: {
           headers: {};
           content: {
@@ -5838,7 +5560,7 @@ class Context {
       },
       "HTTP_PUT" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: User, context: ContextType, response: ResponseBuilderFactory<{
 [statusCode in HttpStatusCode]: {
           headers: {};
           content: {};
@@ -5856,7 +5578,7 @@ class Context {
       },
       "HTTP_DELETE" => Object {
         "beforeExport": "",
-        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: typeof Context, response: ResponseBuilderFactory<{
+        "code": "({ query, path, header, body, context, proxy }: { query: never, path: {\\"username\\": string}, header: never, body: undefined, context: ContextType, response: ResponseBuilderFactory<{
 400: {
           headers: {};
           content: {};
@@ -5886,38 +5608,25 @@ class Context {
       },
     },
     "imports": Map {
-      "Context" => Object {
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+      "ContextType" => Object {
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "script": Script {
           "cache": Map {
-            "default" => "Context",
+            "ContextTypeCoder@[object Object]:true" => "ContextType",
           },
           "exports": Map {
-            "Context" => Object {
-              "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+            "ContextType" => Object {
+              "beforeExport": "",
               "code": Object {
-                "raw": "export { default } from \\"../$.context.mjs\\"",
+                "raw": "export type { ContextType } from \\"../$.context\\"",
               },
               "done": true,
-              "id": "ContextCoder",
-              "isDefault": true,
-              "isType": false,
-              "name": "Context",
+              "id": "ContextTypeCoder",
+              "isDefault": false,
+              "isType": true,
+              "name": "ContextType",
               "promise": Promise {},
               "typeDeclaration": "",
             },
@@ -5974,6 +5683,7 @@ class Context {
   "paths/$.context.ts" => Script {
     "cache": Map {
       "default" => "Context",
+      "ContextTypeCoder@[object Object]:true" => "ContextType",
     },
     "exports": Map {
       "Context" => Object {
@@ -5997,6 +5707,17 @@ class Context {
         "isDefault": true,
         "isType": false,
         "name": "Context",
+        "promise": Promise {},
+        "typeDeclaration": "",
+      },
+      "ContextType" => Object {
+        "beforeExport": "",
+        "code": "typeof Context",
+        "done": true,
+        "id": "ContextTypeCoder",
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "promise": Promise {},
         "typeDeclaration": "",
       },
@@ -6103,32 +5824,19 @@ class Context {
   },
   "paths/pet/$.context.ts" => Script {
     "cache": Map {
-      "default" => "Context",
+      "ContextTypeCoder@[object Object]:true" => "ContextType",
     },
     "exports": Map {
-      "Context" => Object {
-        "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/$.context.ts\\";
-  }
-}
-",
+      "ContextType" => Object {
+        "beforeExport": "",
         "code": Object {
-          "raw": "export { default } from \\"../$.context.mjs\\"",
+          "raw": "export type { ContextType } from \\"../$.context\\"",
         },
         "done": true,
-        "id": "ContextCoder",
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+        "id": "ContextTypeCoder",
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "promise": Promise {},
         "typeDeclaration": "",
       },
@@ -6144,32 +5852,19 @@ class Context {
   },
   "paths/pet/{petId}/$.context.ts" => Script {
     "cache": Map {
-      "default" => "Context",
+      "ContextTypeCoder@[object Object]:true" => "ContextType",
     },
     "exports": Map {
-      "Context" => Object {
-        "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/pet/{petId}/$.context.ts\\";
-  }
-}
-",
+      "ContextType" => Object {
+        "beforeExport": "",
         "code": Object {
-          "raw": "export { default } from \\"../$.context.mjs\\"",
+          "raw": "export type { ContextType } from \\"../$.context\\"",
         },
         "done": true,
-        "id": "ContextCoder",
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+        "id": "ContextTypeCoder",
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "promise": Promise {},
         "typeDeclaration": "",
       },
@@ -6211,32 +5906,19 @@ class Context {
   },
   "paths/store/$.context.ts" => Script {
     "cache": Map {
-      "default" => "Context",
+      "ContextTypeCoder@[object Object]:true" => "ContextType",
     },
     "exports": Map {
-      "Context" => Object {
-        "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/$.context.ts\\";
-  }
-}
-",
+      "ContextType" => Object {
+        "beforeExport": "",
         "code": Object {
-          "raw": "export { default } from \\"../$.context.mjs\\"",
+          "raw": "export type { ContextType } from \\"../$.context\\"",
         },
         "done": true,
-        "id": "ContextCoder",
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+        "id": "ContextTypeCoder",
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "promise": Promise {},
         "typeDeclaration": "",
       },
@@ -6278,32 +5960,19 @@ class Context {
   },
   "paths/store/order/$.context.ts" => Script {
     "cache": Map {
-      "default" => "Context",
+      "ContextTypeCoder@[object Object]:true" => "ContextType",
     },
     "exports": Map {
-      "Context" => Object {
-        "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/store/order/$.context.ts\\";
-  }
-}
-",
+      "ContextType" => Object {
+        "beforeExport": "",
         "code": Object {
-          "raw": "export { default } from \\"../$.context.mjs\\"",
+          "raw": "export type { ContextType } from \\"../$.context\\"",
         },
         "done": true,
-        "id": "ContextCoder",
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+        "id": "ContextTypeCoder",
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "promise": Promise {},
         "typeDeclaration": "",
       },
@@ -6345,32 +6014,19 @@ class Context {
   },
   "paths/user/$.context.ts" => Script {
     "cache": Map {
-      "default" => "Context",
+      "ContextTypeCoder@[object Object]:true" => "ContextType",
     },
     "exports": Map {
-      "Context" => Object {
-        "beforeExport": "/**
-* This is the default context for Counterfact.
-* Change the code to suit your needs.
-*/
-class Context {
-  // delete this line to make the class type safe
-  [key: string]: any; 
-
-  // A helper when you accessing the context object via the REPL. You can delete it if you like.
-  [Symbol.for('nodejs.util.inspect.custom')](depth, options, inspect) {
-    return inspect(this, { ...options, customInspect: false }) + \\"\\\\n\\\\n ^ This is the default context object. You can edit its definition at paths/user/$.context.ts\\";
-  }
-}
-",
+      "ContextType" => Object {
+        "beforeExport": "",
         "code": Object {
-          "raw": "export { default } from \\"../$.context.mjs\\"",
+          "raw": "export type { ContextType } from \\"../$.context\\"",
         },
         "done": true,
-        "id": "ContextCoder",
-        "isDefault": true,
-        "isType": false,
-        "name": "Context",
+        "id": "ContextTypeCoder",
+        "isDefault": false,
+        "isType": true,
+        "name": "ContextType",
         "promise": Promise {},
         "typeDeclaration": "",
       },

--- a/test/typescript-generator/__snapshots__/operation-type-coder.test.js.snap
+++ b/test/typescript-generator/__snapshots__/operation-type-coder.test.js.snap
@@ -13,7 +13,7 @@ exports[`an OperationTypeCoder falls back to root level produces (OpenAPI 2) 1`]
   path: never;
   header: never;
   body: undefined;
-  context: typeof default;
+  context: Type;
   response: ResponseBuilderFactory<{
     [statusCode in HttpStatusCode]: {
       headers: {};
@@ -49,7 +49,7 @@ exports[`an OperationTypeCoder generates a complex post operation (OpenAPI 2 wit
   path: { \\"id?\\": string };
   header: { \\"name?\\": string };
   body: Type;
-  context: typeof default;
+  context: Type;
   response: ResponseBuilderFactory<{
     200: {
       headers: {};
@@ -111,7 +111,7 @@ exports[`an OperationTypeCoder generates a complex post operation (OpenAPI 2) 1`
   path: { \\"id?\\": string };
   header: { \\"name?\\": string };
   body: Type;
-  context: typeof default;
+  context: Type;
   response: ResponseBuilderFactory<{
     200: {
       headers: {};
@@ -173,7 +173,7 @@ exports[`an OperationTypeCoder generates a complex post operation 1`] = `
   path: { \\"id?\\": string };
   header: { \\"name?\\": string };
   body: Type;
-  context: typeof default;
+  context: Type;
   response: ResponseBuilderFactory<{
     200: {
       headers: {};
@@ -235,7 +235,7 @@ exports[`an OperationTypeCoder generates a simple get operation (OpenAPI 2) 1`] 
   path: never;
   header: never;
   body: undefined;
-  context: typeof default;
+  context: Type;
   response: ResponseBuilderFactory<{
     [statusCode in HttpStatusCode]: {
       headers: {};
@@ -271,7 +271,7 @@ exports[`an OperationTypeCoder generates a simple get operation 1`] = `
   path: never;
   header: never;
   body: undefined;
-  context: typeof default;
+  context: Type;
   response: ResponseBuilderFactory<{
     [statusCode in HttpStatusCode]: {
       headers: {};

--- a/test/typescript-generator/context-coder.test.js
+++ b/test/typescript-generator/context-coder.test.js
@@ -62,14 +62,6 @@ describe("a ContextCoder", () => {
     expect(coder.id).toBe("ContextCoder");
   });
 
-  it("extends the Context from the parent directory", async () => {
-    const coder = new ContextCoder(new Requirement({}, "#/paths/hello/get"));
-
-    await expect(format(coder.write(dummyScript).raw)).resolves.toBe(
-      await format('export { default } from "../$.context.mjs";'),
-    );
-  });
-
   it("returns the context object if this is the root directory", async () => {
     const coder = new ContextCoder(new Requirement({}, "#/paths/hello"));
 

--- a/test/typescript-generator/context-type-coder.test.js
+++ b/test/typescript-generator/context-type-coder.test.js
@@ -1,0 +1,63 @@
+import prettier from "prettier";
+
+import { ContextTypeCoder } from "../../src/typescript-generator/context-type-coder.js";
+import { Requirement } from "../../src/typescript-generator/requirement.js";
+
+function format(code) {
+  return prettier.format(code, { parser: "typescript" });
+}
+
+const dummyScript = {
+  import() {
+    return "schema";
+  },
+
+  importDefault() {
+    return "default";
+  },
+
+  importExternalType() {
+    return "ExternalType";
+  },
+
+  importType() {
+    return "Type";
+  },
+
+  path: ".",
+
+  repository: {
+    get() {
+      return {
+        exportDefault() {
+          return "noop";
+        },
+      };
+    },
+  },
+};
+
+describe("a ContextTypeCoder", () => {
+  it("extends the Context from the parent directory", async () => {
+    const coder = new ContextTypeCoder(
+      new Requirement({}, "#/paths/hello/get"),
+    );
+
+    await expect(format(coder.write(dummyScript).raw)).resolves.toBe(
+      await format('export type { ContextType } from "../$.context";'),
+    );
+  });
+
+  it("exports typeof Context in the root", async () => {
+    const coder = new ContextTypeCoder(new Requirement({}, "#/paths"));
+
+    const dummyScriptWithRootPath = {
+      ...dummyScript,
+      path: "paths/$.context.ts",
+    };
+
+    await expect(format(coder.write(dummyScriptWithRootPath))).resolves.toBe(
+      await format("typeof Context"),
+    );
+  });
+});


### PR DESCRIPTION
Fixes an issue where each directory under paths had its own copy of the context object. As it stands, this is a breaking change: existing `$.context.ts` files won't work. Need to add a migration to detect and fix legacy files. 

fixes #604 