### PR TITLE
configure json-schema-faker to create between 0 and 20 items 

### DIFF
--- a/.changeset/wild-bees-hammer.md
+++ b/.changeset/wild-bees-hammer.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+configure json-schema-aker to create between 0 and 20 items when it generates an array

--- a/src/server/response-builder.ts
+++ b/src/server/response-builder.ts
@@ -25,6 +25,8 @@ interface OpenApiContent {
 }
 
 JSONSchemaFaker.option("useExamplesValue", true);
+JSONSchemaFaker.option("minItems", 0);
+JSONSchemaFaker.option("maxItems", 20);
 
 function oneOf(items: unknown[] | { [key: string]: unknown }): unknown {
   if (Array.isArray(items)) {


### PR DESCRIPTION
when it generates an array