### PR TITLE
add changesets to Renovate updates

### DIFF
--- a/.github/workflows/renovte-changeset.yaml
+++ b/.github/workflows/renovte-changeset.yaml
@@ -1,0 +1,20 @@
+name: Add changeset to Renovate updates
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, labeled]
+
+jobs:
+  renovate:
+    name: Update Renovate PR
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies')
+
+    steps:
+      - name: Update PR
+        uses: mscharley/dependency-changesets-action@v1.0.0
+        with:
+          token: ${{ secrets.DEPENDENCY_UPDATE_GITHUB_TOKEN }}
+          use-semantic-commits: true
+          author-name: Renovate Changesets
+          author-email: github+renovate@scharley.me

--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,12 @@
   "extends": ["config:base"],
   "rangeStrategy": "update-lockfile",
   "enabledManagers": ["npm", "github-actions"],
+  "gitIgnoredAuthors": ["github+renovate@scharley.me"],
   "packageRules": [
     {
       "matchManagers": ["npm"],
       "description": "Automatically merge all updates",
+      "addLabels": ["npm", "dependencies"],
       "automerge": true,
       "stabilityDays": 3,
       "prCreation": "not-pending",
@@ -14,8 +16,8 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "addLabels": ["github_actions"],
       "description": "Automatically merge all updates",
+      "addLabels": ["github_actions", "dependencies"],
       "automerge": true,
       "stabilityDays": 3,
       "prCreation": "not-pending"


### PR DESCRIPTION
In theory, this will cause the changelog to be updated when Renovate updates dependencies.