### PR TITLE
feat(server): Add dispatcher logic to allow handling requests container OpenApi basePath

### DIFF
--- a/.changeset/sweet-nails-itch.md
+++ b/.changeset/sweet-nails-itch.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Allows Counterfact to handle requests that contain the OpenApi basePath

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -231,7 +231,7 @@ export class Dispatcher {
     // If the incoming path includes the base path, remove it
     if (
       this.openApiDocument?.basePath !== undefined &&
-      path.toLowerCase().includes(this.openApiDocument.basePath.toLowerCase())
+      path.toLowerCase().startsWith(this.openApiDocument.basePath.toLowerCase())
     ) {
       // eslint-disable-next-line security/detect-non-literal-regexp
       path = path.replace(new RegExp(this.openApiDocument.basePath, "iu"), "");

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -40,6 +40,7 @@ interface ParameterTypes {
 }
 
 export interface OpenApiDocument {
+  basePath?: string;
   paths: {
     [key: string]: {
       [key in Lowercase<HttpMethods>]?: OpenApiOperation;
@@ -203,7 +204,7 @@ export class Dispatcher {
     return false;
   }
 
-  // eslint-disable-next-line sonarjs/cognitive-complexity
+  // eslint-disable-next-line sonarjs/cognitive-complexity, max-statements
   public async request({
     body,
     headers = {},
@@ -226,6 +227,15 @@ export class Dispatcher {
     };
   }): Promise<NormalizedCounterfactResponseObject> {
     debug(`request: ${method} ${path}`);
+
+    // If the incoming path includes the base path, remove it
+    if (
+      this.openApiDocument?.basePath !== undefined &&
+      path.toLowerCase().includes(this.openApiDocument.basePath.toLowerCase())
+    ) {
+      // eslint-disable-next-line security/detect-non-literal-regexp
+      path = path.replace(new RegExp(this.openApiDocument.basePath, "iu"), "");
+    }
 
     const { matchedPath } = this.registry.handler(path);
     const operation = this.operationForPathAndMethod(matchedPath, method);

--- a/test/server/dispatcher.test.ts
+++ b/test/server/dispatcher.test.ts
@@ -769,3 +769,53 @@ describe("given an invalid path", () => {
     );
   });
 });
+
+describe("given a request that contains the OpenApi basePath", () => {
+  it("strips the basePath from the path before finding the associated handler", async () => {
+    const registry = new Registry();
+
+    registry.add("/abc", {
+      POST() {
+        return {
+          body: "ok",
+          status: 200,
+        };
+      },
+    });
+
+    const dispatcher = new Dispatcher(registry, new ContextRegistry(), {
+      basePath: "/api",
+
+      paths: {
+        "/abc": {
+          post: {
+            responses: {
+              200: {
+                content: {
+                  "text/plain": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const response = await dispatcher.request({
+      body: "",
+      headers: {},
+      method: "POST",
+      path: "/api/abc",
+      query: {},
+      req: { path: "/api/abc" },
+    });
+
+    expect(response.status).toBe(200);
+
+    expect(response.body).toBe("ok");
+  });
+});


### PR DESCRIPTION
Updates the Dispatcher logic to allow requests that contain the OpenApi `basePath` at the root of the path. For example, if the `basePath` is `/myApi` and a consumer of the mock service makes a call to `/myApi/someEndpoint` the present code will give a 404. This change allows handling of that request just as if the consumer called `/someEndpoint`. Some consumers in a webpack proxy situation are sending the `basePath` in the request path and this allows handling that situation.