### PR TITLE
strengthen the return type of an operations

### DIFF
--- a/.changeset/quiet-starfishes-hang.md
+++ b/.changeset/quiet-starfishes-hang.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+strengthen the return type of an operation (the return value of GET(), POST(), etc.)

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -113,10 +113,10 @@ export class OperationTypeCoder extends Coder {
         this.requirement.specification?.rootRequirement?.get("produces")?.data,
     ).write(script);
 
-    const proxyType = "(url: string) => { proxyUrl: string }";
+    const proxyType = '(url: string) => "COUNTERFACT_RESPONSE"';
 
     return `($: OmitValueWhenNever<{ query: ${queryType}, path: ${pathType}, header: ${headerType}, body: ${bodyType}, context: ${contextTypeImportName}, response: ${responseType}, x: ${xType}, proxy: ${proxyType} }>) => ${this.responseTypes(
       script,
-    )} | { status: 415, contentType: "text/plain", body: string } | { }`;
+    )} | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"`;
   }
 }

--- a/test/typescript-generator/__snapshots__/generate.test.ts.snap
+++ b/test/typescript-generator/__snapshots__/generate.test.ts.snap
@@ -74,7 +74,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -84,7 +84,7 @@ Map {
               body?: Pet
             } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet/post",
               "isDefault": false,
@@ -119,7 +119,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -133,7 +133,7 @@ Map {
           status: 404 
         } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet/put",
               "isDefault": false,
@@ -304,7 +304,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -314,7 +314,7 @@ Map {
               body?: Pet
             } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet/post",
               "isDefault": false,
@@ -349,7 +349,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -363,7 +363,7 @@ Map {
           status: 404 
         } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet/put",
               "isDefault": false,
@@ -538,7 +538,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -548,7 +548,7 @@ Map {
               body?: Pet
             } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet/post",
         "isDefault": false,
@@ -583,7 +583,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -597,7 +597,7 @@ Map {
           status: 404 
         } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet/put",
         "isDefault": false,
@@ -789,7 +789,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Array<Pet>
@@ -799,7 +799,7 @@ Map {
               body?: Array<Pet>
             } | {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByStatus/get",
               "isDefault": false,
@@ -973,7 +973,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Array<Pet>
@@ -983,7 +983,7 @@ Map {
               body?: Array<Pet>
             } | {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByStatus/get",
         "isDefault": false,
@@ -1175,7 +1175,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Array<Pet>
@@ -1185,7 +1185,7 @@ Map {
               body?: Array<Pet>
             } | {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByTags/get",
               "isDefault": false,
@@ -1359,7 +1359,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Array<Pet>
@@ -1369,7 +1369,7 @@ Map {
               body?: Array<Pet>
             } | {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1findByTags/get",
         "isDefault": false,
@@ -1597,7 +1597,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -1609,7 +1609,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get",
               "isDefault": false,
@@ -1625,9 +1625,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post",
               "isDefault": false,
@@ -1643,9 +1643,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete",
               "isDefault": false,
@@ -1821,7 +1821,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -1833,7 +1833,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get",
               "isDefault": false,
@@ -1849,9 +1849,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post",
               "isDefault": false,
@@ -1867,9 +1867,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete",
               "isDefault": false,
@@ -2045,7 +2045,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -2057,7 +2057,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get",
               "isDefault": false,
@@ -2073,9 +2073,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post",
               "isDefault": false,
@@ -2091,9 +2091,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete",
               "isDefault": false,
@@ -2273,7 +2273,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Pet
@@ -2285,7 +2285,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/get",
         "isDefault": false,
@@ -2301,9 +2301,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/post",
         "isDefault": false,
@@ -2319,9 +2319,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}/delete",
         "isDefault": false,
@@ -2506,11 +2506,11 @@ Map {
          }
 };
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/json",
               body?: ApiResponse
-            } | { status: 415, contentType: "text/plain", body: string } | { }",
+            } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}~1uploadImage/post",
               "isDefault": false,
@@ -2610,11 +2610,11 @@ Map {
          }
 };
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/json",
               body?: ApiResponse
-            } | { status: 415, contentType: "text/plain", body: string } | { }",
+            } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1pet~1{petId}~1uploadImage/post",
         "isDefault": false,
@@ -2731,11 +2731,11 @@ Map {
          }
 };
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/json",
               body?: {[key: string]: number}
-            } | { status: 415, contentType: "text/plain", body: string } | { }",
+            } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1inventory/get",
               "isDefault": false,
@@ -2801,11 +2801,11 @@ Map {
          }
 };
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/json",
               body?: {[key: string]: number}
-            } | { status: 415, contentType: "text/plain", body: string } | { }",
+            } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1inventory/get",
         "isDefault": false,
@@ -2894,13 +2894,13 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/json",
               body?: Order
             } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order/post",
               "isDefault": false,
@@ -3004,13 +3004,13 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/json",
               body?: Order
             } | {  
           status: 405 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order/post",
         "isDefault": false,
@@ -3155,7 +3155,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Order
@@ -3167,7 +3167,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/get",
               "isDefault": false,
@@ -3187,11 +3187,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/delete",
               "isDefault": false,
@@ -3299,7 +3299,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Order
@@ -3311,7 +3311,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/get",
               "isDefault": false,
@@ -3331,11 +3331,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/delete",
               "isDefault": false,
@@ -3447,7 +3447,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: Order
@@ -3459,7 +3459,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/get",
         "isDefault": false,
@@ -3479,11 +3479,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1store~1order~1{orderId}/delete",
         "isDefault": false,
@@ -3604,7 +3604,7 @@ Map {
          }
 };
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: number | undefined, 
               contentType?: "application/json",
               body?: User
@@ -3612,7 +3612,7 @@ Map {
               status: number | undefined, 
               contentType?: "application/xml",
               body?: User
-            } | { status: 415, contentType: "text/plain", body: string } | { }",
+            } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user/post",
               "isDefault": false,
@@ -3719,7 +3719,7 @@ Map {
          }
 };
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: number | undefined, 
               contentType?: "application/json",
               body?: User
@@ -3727,7 +3727,7 @@ Map {
               status: number | undefined, 
               contentType?: "application/xml",
               body?: User
-            } | { status: 415, contentType: "text/plain", body: string } | { }",
+            } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user/post",
         "isDefault": false,
@@ -3856,7 +3856,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: User
@@ -3866,7 +3866,7 @@ Map {
               body?: User
             } | {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1createWithList/post",
               "isDefault": false,
@@ -3977,7 +3977,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: User
@@ -3987,7 +3987,7 @@ Map {
               body?: User
             } | {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1createWithList/post",
         "isDefault": false,
@@ -4118,7 +4118,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: string
@@ -4128,7 +4128,7 @@ Map {
               body?: string
             } | {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1login/get",
               "isDefault": false,
@@ -4204,7 +4204,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: string
@@ -4214,7 +4214,7 @@ Map {
               body?: string
             } | {  
           status: 400 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1login/get",
         "isDefault": false,
@@ -4294,9 +4294,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1logout/get",
               "isDefault": false,
@@ -4362,9 +4362,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1logout/get",
         "isDefault": false,
@@ -4496,7 +4496,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: User
@@ -4508,7 +4508,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get",
               "isDefault": false,
@@ -4524,9 +4524,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put",
               "isDefault": false,
@@ -4546,11 +4546,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete",
               "isDefault": false,
@@ -4663,7 +4663,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: User
@@ -4675,7 +4675,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get",
               "isDefault": false,
@@ -4691,9 +4691,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put",
               "isDefault": false,
@@ -4713,11 +4713,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete",
               "isDefault": false,
@@ -4830,7 +4830,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: User
@@ -4842,7 +4842,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get",
               "isDefault": false,
@@ -4858,9 +4858,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put",
               "isDefault": false,
@@ -4880,11 +4880,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
               "done": true,
               "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete",
               "isDefault": false,
@@ -5001,7 +5001,7 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
               status: 200, 
               contentType?: "application/xml",
               body?: User
@@ -5013,7 +5013,7 @@ Map {
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/get",
         "isDefault": false,
@@ -5029,9 +5029,9 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: number | undefined 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/put",
         "isDefault": false,
@@ -5051,11 +5051,11 @@ Map {
           headers: {};
           content: {};
         }
-}>, x: WideOperationArgument, proxy: (url: string) => { proxyUrl: string } }>) => {  
+}>, x: WideOperationArgument, proxy: (url: string) => "COUNTERFACT_RESPONSE" }>) => {  
           status: 400 
         } | {  
           status: 404 
-        } | { status: 415, contentType: "text/plain", body: string } | { }",
+        } | { status: 415, contentType: "text/plain", body: string } | "COUNTERFACT_RESPONSE"",
         "done": true,
         "id": "OperationTypeCoder@./petstore.yaml#/paths/~1user~1{username}/delete",
         "isDefault": false,

--- a/test/typescript-generator/__snapshots__/operation-type-coder.test.js.snap
+++ b/test/typescript-generator/__snapshots__/operation-type-coder.test.js.snap
@@ -19,7 +19,7 @@ exports[`an OperationTypeCoder falls back to root level produces (OpenAPI 2) 1`]
       };
     }>;
     x: SharedType;
-    proxy: (url: string) => { proxyUrl: string };
+    proxy: (url: string) => "COUNTERFACT_RESPONSE";
   }>,
 ) =>
   | {
@@ -28,7 +28,7 @@ exports[`an OperationTypeCoder falls back to root level produces (OpenAPI 2) 1`]
       body?: Type;
     }
   | { status: 415; contentType: "text/plain"; body: string }
-  | {};
+  | "COUNTERFACT_RESPONSE";
 "
 `;
 
@@ -67,7 +67,7 @@ exports[`an OperationTypeCoder generates a complex post operation (OpenAPI 2 wit
       };
     }>;
     x: SharedType;
-    proxy: (url: string) => { proxyUrl: string };
+    proxy: (url: string) => "COUNTERFACT_RESPONSE";
   }>,
 ) =>
   | {
@@ -86,7 +86,7 @@ exports[`an OperationTypeCoder generates a complex post operation (OpenAPI 2 wit
       body?: Type;
     }
   | { status: 415; contentType: "text/plain"; body: string }
-  | {};
+  | "COUNTERFACT_RESPONSE";
 "
 `;
 
@@ -125,7 +125,7 @@ exports[`an OperationTypeCoder generates a complex post operation (OpenAPI 2) 1`
       };
     }>;
     x: SharedType;
-    proxy: (url: string) => { proxyUrl: string };
+    proxy: (url: string) => "COUNTERFACT_RESPONSE";
   }>,
 ) =>
   | {
@@ -144,7 +144,7 @@ exports[`an OperationTypeCoder generates a complex post operation (OpenAPI 2) 1`
       body?: Type;
     }
   | { status: 415; contentType: "text/plain"; body: string }
-  | {};
+  | "COUNTERFACT_RESPONSE";
 "
 `;
 
@@ -183,7 +183,7 @@ exports[`an OperationTypeCoder generates a complex post operation 1`] = `
       };
     }>;
     x: SharedType;
-    proxy: (url: string) => { proxyUrl: string };
+    proxy: (url: string) => "COUNTERFACT_RESPONSE";
   }>,
 ) =>
   | {
@@ -202,7 +202,7 @@ exports[`an OperationTypeCoder generates a complex post operation 1`] = `
       body?: Type;
     }
   | { status: 415; contentType: "text/plain"; body: string }
-  | {};
+  | "COUNTERFACT_RESPONSE";
 "
 `;
 
@@ -225,7 +225,7 @@ exports[`an OperationTypeCoder generates a simple get operation (OpenAPI 2) 1`] 
       };
     }>;
     x: SharedType;
-    proxy: (url: string) => { proxyUrl: string };
+    proxy: (url: string) => "COUNTERFACT_RESPONSE";
   }>,
 ) =>
   | {
@@ -234,7 +234,7 @@ exports[`an OperationTypeCoder generates a simple get operation (OpenAPI 2) 1`] 
       body?: Type;
     }
   | { status: 415; contentType: "text/plain"; body: string }
-  | {};
+  | "COUNTERFACT_RESPONSE";
 "
 `;
 
@@ -257,7 +257,7 @@ exports[`an OperationTypeCoder generates a simple get operation 1`] = `
       };
     }>;
     x: SharedType;
-    proxy: (url: string) => { proxyUrl: string };
+    proxy: (url: string) => "COUNTERFACT_RESPONSE";
   }>,
 ) =>
   | {
@@ -266,6 +266,6 @@ exports[`an OperationTypeCoder generates a simple get operation 1`] = `
       body?: Type;
     }
   | { status: 415; contentType: "text/plain"; body: string }
-  | {};
+  | "COUNTERFACT_RESPONSE";
 "
 `;


### PR DESCRIPTION
The return type for operations `GET()`, `POST()`, etc. previously included `{}`, which meant that basically anything would type check.

This changes ensures the return type is a complete response. It either contains all of the headers and content types specified by OpenAPI or it's something like `random()` where the actual type is hard to determine at compile-time but we know it will work at run-time. 