### PR TITLE
temporary workaround so random() type checks even if a header is missing

### DIFF
--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -71,10 +71,7 @@ type HeaderFunction<Response extends OpenApiResponse> = <
 
 type RandomFunction<Response extends OpenApiResponse> = <
   Header extends string & keyof Response["headers"],
->() => GenericResponseBuilder<OmitValueWhenNever<{
-  content: never;
-  headers: NeverIfEmpty<Response["headers"]>;
-}>>;
+>() => "COUNTERFACT_RESPONSE";
 
 interface ResponseBuilder {
   [status: number | `${number} ${string}`]: ResponseBuilder;


### PR DESCRIPTION
If the OpenAPI spec specifies a response header, this should type check. 

```ts
export const GET: HTTP_GET = ($) => {
  return $.response[200].random();
}
```

Currently the `random()` function doesn't generate response headers, but it should. 

If you want to specify the header value, this should work.

```ts
export const GET: HTTP_GET = ($) => {
  return $.response[200].header("x-test", "foo").random();
}
```

And this should work too (theoretically), but it currently does not type check.

```ts
export const GET: HTTP_GET = ($) => {
  return $.response[200].random().header("x-test", "foo");
}
```

This is a quick fix so I can get a release out. Going to work on making all this stuff right next.