### PR TITLE
fix(dispatcher): Fix dispatcher.findOperation to use case insensitive match

### DIFF
--- a/.changeset/bright-rockets-cheer.md
+++ b/.changeset/bright-rockets-cheer.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Updates dispatcher class to ignore case when matching paths

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -97,15 +97,28 @@ export class Dispatcher {
     return types;
   }
 
+  private findOperation(
+    path: string,
+    method: HttpMethods,
+  ): OpenApiOperation | undefined {
+    for (const key in this.openApiDocument?.paths) {
+      if (key.toLowerCase() === path.toLowerCase()) {
+        return this.openApiDocument.paths[key]?.[
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          method.toLowerCase() as Lowercase<HttpMethods>
+        ];
+        break;
+      }
+    }
+
+    return undefined;
+  }
+
   public operationForPathAndMethod(
     path: string,
     method: HttpMethods,
   ): OpenApiOperation | undefined {
-    const operation: OpenApiOperation | undefined =
-      this.openApiDocument?.paths[path]?.[
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        method.toLowerCase() as Lowercase<HttpMethods>
-      ];
+    const operation = this.findOperation(path, method);
 
     if (operation === undefined) {
       return undefined;

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -101,13 +101,14 @@ export class Dispatcher {
     path: string,
     method: HttpMethods,
   ): OpenApiOperation | undefined {
-    for (const key in this.openApiDocument?.paths) {
-      if (key.toLowerCase() === path.toLowerCase()) {
-        return this.openApiDocument.paths[key]?.[
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          method.toLowerCase() as Lowercase<HttpMethods>
-        ];
-        break;
+    if (this.openApiDocument) {
+      for (const key in this.openApiDocument.paths) {
+        if (key.toLowerCase() === path.toLowerCase()) {
+          return this.openApiDocument.paths[key]?.[
+            // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+            method.toLowerCase() as Lowercase<HttpMethods>
+          ];
+        }
       }
     }
 

--- a/test/server/dispatcher.test.ts
+++ b/test/server/dispatcher.test.ts
@@ -818,3 +818,51 @@ describe("given a request that contains the OpenApi basePath", () => {
     expect(response.body).toBe("ok");
   });
 });
+
+describe("given a request that contains the differently cased path", () => {
+  it("correctly returns the desired path response even when case of path does not match", async () => {
+    const registry = new Registry();
+
+    registry.add("/abc", {
+      POST() {
+        return {
+          body: "ok",
+          status: 200,
+        };
+      },
+    });
+
+    const dispatcher = new Dispatcher(registry, new ContextRegistry(), {
+      paths: {
+        "/Abc": {
+          post: {
+            responses: {
+              200: {
+                content: {
+                  "text/plain": {
+                    schema: {
+                      type: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const response = await dispatcher.request({
+      body: "",
+      headers: {},
+      method: "POST",
+      path: "/abc",
+      query: {},
+      req: { path: "/abc" },
+    });
+
+    expect(response.status).toBe(200);
+
+    expect(response.body).toBe("ok");
+  });
+});

--- a/test/server/dispatcher.test.ts
+++ b/test/server/dispatcher.test.ts
@@ -852,13 +852,26 @@ describe("given a request that contains the differently cased path", () => {
       },
     });
 
-    const response = await dispatcher.request({
+    let response = await dispatcher.request({
       body: "",
       headers: {},
       method: "POST",
       path: "/abc",
       query: {},
       req: { path: "/abc" },
+    });
+
+    expect(response.status).toBe(200);
+
+    expect(response.body).toBe("ok");
+
+    response = await dispatcher.request({
+      body: "",
+      headers: {},
+      method: "POST",
+      path: "/ABC",
+      query: {},
+      req: { path: "/ABC" },
     });
 
     expect(response.status).toBe(200);


### PR DESCRIPTION
Updates `dispatcher` class to ignore case when finding operations for a given path. This brings it in line with the already case-insensitive logic present in the registry.