### PR TITLE
pass requestMethod to the constructor of OperationCoder / OperationTypeCoder

### DIFF
--- a/src/typescript-generator/generate.js
+++ b/src/typescript-generator/generate.js
@@ -80,8 +80,10 @@ export async function generate(
 
   paths.forEach((pathDefinition, key) => {
     debug("processing path %s", key);
-    pathDefinition.forEach((operation) => {
-      repository.get(`paths${key}.ts`).export(new OperationCoder(operation));
+    pathDefinition.forEach((operation, requestMethod) => {
+      repository
+        .get(`paths${key}.ts`)
+        .export(new OperationCoder(operation, requestMethod));
     });
   });
 

--- a/src/typescript-generator/operation-coder.js
+++ b/src/typescript-generator/operation-coder.js
@@ -5,12 +5,18 @@ import { Coder } from "./coder.js";
 import { OperationTypeCoder } from "./operation-type-coder.js";
 
 export class OperationCoder extends Coder {
-  requestMethod() {
-    return this.requirement.url.split("/").at(-1).toUpperCase();
+  constructor(requirement, requestMethod) {
+    super(requirement);
+
+    if (requestMethod === undefined) {
+      throw new Error("requestMethod is required");
+    }
+
+    this.requestMethod = requestMethod;
   }
 
   names() {
-    return super.names(this.requestMethod());
+    return super.names(this.requestMethod.toUpperCase());
   }
 
   write() {
@@ -37,7 +43,10 @@ export class OperationCoder extends Coder {
   }
 
   typeDeclaration(namespace, script) {
-    const operationTypeCoder = new OperationTypeCoder(this.requirement);
+    const operationTypeCoder = new OperationTypeCoder(
+      this.requirement,
+      this.requestMethod,
+    );
 
     return script.importType(operationTypeCoder);
   }

--- a/src/typescript-generator/operation-type-coder.js
+++ b/src/typescript-generator/operation-type-coder.js
@@ -8,10 +8,18 @@ import { ResponseTypeCoder } from "./response-type-coder.js";
 import { SchemaTypeCoder } from "./schema-type-coder.js";
 
 export class OperationTypeCoder extends Coder {
+  constructor(requirement, requestMethod) {
+    super(requirement);
+
+    if (requestMethod === undefined) {
+      throw new Error("requestMethod is required");
+    }
+
+    this.requestMethod = requestMethod;
+  }
+
   names() {
-    return super.names(
-      `HTTP_${this.requirement.url.split("/").at(-1).toUpperCase()}`,
-    );
+    return super.names(`HTTP_${this.requestMethod.toUpperCase()}`);
   }
 
   responseTypes(script) {

--- a/test/typescript-generator/operation-coder.test.js
+++ b/test/typescript-generator/operation-coder.test.js
@@ -9,23 +9,21 @@ function format(code) {
 
 describe("an OperationCoder", () => {
   it("generates a list of potential names", () => {
-    const coder = new OperationCoder(new Requirement({}, "#/paths/hello/get"));
+    const coder = new OperationCoder(
+      new Requirement({}, "#/paths/hello/get"),
+      "get",
+    );
 
     const [one, two, three] = coder.names();
 
     expect([one, two, three]).toStrictEqual(["GET", "GET2", "GET3"]);
   });
 
-  it("finds the request method in the URL", () => {
-    const get = new OperationCoder(new Requirement({}, "#/paths/hello/get"));
-    const put = new OperationCoder(new Requirement({}, "#/paths/hello/put"));
-
-    expect(get.requestMethod()).toBe("GET");
-    expect(put.requestMethod()).toBe("PUT");
-  });
-
   it("creates a type declaration", () => {
-    const coder = new OperationCoder(new Requirement({}, "#/paths/hello/get"));
+    const coder = new OperationCoder(
+      new Requirement({}, "#/paths/hello/get"),
+      "get",
+    );
 
     const script = {
       importType() {
@@ -38,7 +36,8 @@ describe("an OperationCoder", () => {
 
   it("returns the module path", () => {
     const coder = new OperationCoder(
-      new Requirement({}, "#/paths/hello~1world/get"),
+      new Requirement({}, "#/paths/hello~1world/get", "get"),
+      "get",
     );
 
     expect(coder.modulePath()).toBe("path/hello/world.types.ts");
@@ -91,7 +90,7 @@ describe("an OperationCoder", () => {
       "#/paths/hello/get",
     );
 
-    const coder = new OperationCoder(requirement);
+    const coder = new OperationCoder(requirement, "get");
 
     await expect(
       format(
@@ -124,7 +123,7 @@ describe("an OperationCoder", () => {
       "#/paths/hello/post",
     );
 
-    const coder = new OperationCoder(requirement);
+    const coder = new OperationCoder(requirement, "get");
 
     await expect(
       format(

--- a/test/typescript-generator/operation-type-coder.test.js
+++ b/test/typescript-generator/operation-type-coder.test.js
@@ -36,6 +36,7 @@ describe("an OperationTypeCoder", () => {
   it("generates a list of potential names", () => {
     const coder = new OperationTypeCoder(
       new Requirement({}, "#/paths/hello/get"),
+      "get",
     );
 
     const [one, two, three] = coder.names();
@@ -50,6 +51,7 @@ describe("an OperationTypeCoder", () => {
   it("creates a type declaration", () => {
     const coder = new OperationTypeCoder(
       new Requirement({}, "#/paths/hello/get"),
+      "get",
     );
 
     expect(coder.typeDeclaration(undefined, dummyScript)).toBe("");
@@ -58,6 +60,7 @@ describe("an OperationTypeCoder", () => {
   it("returns the module path", () => {
     const coder = new OperationTypeCoder(
       new Requirement({}, "#/paths/hello~1world/get"),
+      "get",
     );
 
     expect(coder.modulePath()).toBe("path-types/hello/world.types.ts");
@@ -119,7 +122,7 @@ describe("an OperationTypeCoder", () => {
       "#/paths/hello/post",
     );
 
-    const coder = new OperationTypeCoder(requirement);
+    const coder = new OperationTypeCoder(requirement, "get");
 
     await expect(
       format(`type TestType = ${coder.write(dummyScript)}`),
@@ -161,7 +164,7 @@ describe("an OperationTypeCoder", () => {
       "#/paths/hello/post",
     );
 
-    const coder = new OperationTypeCoder(requirement);
+    const coder = new OperationTypeCoder(requirement, "get");
 
     await expect(
       format(`type TestType = ${coder.write(dummyScript)}`),
@@ -210,7 +213,7 @@ describe("an OperationTypeCoder", () => {
       specification,
     );
 
-    const coder = new OperationTypeCoder(requirement);
+    const coder = new OperationTypeCoder(requirement, "get");
 
     await expect(
       format(`type TestType = ${coder.write(dummyScript)}`),
@@ -233,7 +236,7 @@ describe("an OperationTypeCoder", () => {
       "#/paths/hello/get",
     );
 
-    const coder = new OperationTypeCoder(requirement);
+    const coder = new OperationTypeCoder(requirement, "get");
 
     await expect(
       format(`type TestType =${coder.write(dummyScript)}`),
@@ -254,7 +257,7 @@ describe("an OperationTypeCoder", () => {
       "#/paths/hello/get",
     );
 
-    const coder = new OperationTypeCoder(requirement);
+    const coder = new OperationTypeCoder(requirement, "get");
 
     await expect(
       format(`type TestType =${coder.write(dummyScript)}`),
@@ -275,7 +278,7 @@ describe("an OperationTypeCoder", () => {
       "#/paths/hello/get",
     );
 
-    const coder = new OperationTypeCoder(requirement);
+    const coder = new OperationTypeCoder(requirement, "get");
 
     await expect(
       format(`type TestType =${coder.write(dummyScript)}`),


### PR DESCRIPTION
That makes the code a bit easier to follow, particularly in generate.js
