### PR TITLE
reload everything when a file changes

### DIFF
--- a/src/server/context-registry.ts
+++ b/src/server/context-registry.ts
@@ -31,8 +31,14 @@ export class ContextRegistry {
     return this.entries.get(path) ?? this.find(parentPath(path));
   }
 
+  // eslint-disable-next-line max-statements
   public update(path: string, updatedContext?: Context): void {
     if (updatedContext === undefined) {
+      return;
+    }
+
+    if (!this.entries.has(path)) {
+      this.add(path, updatedContext);
       return;
     }
 

--- a/src/server/context-registry.ts
+++ b/src/server/context-registry.ts
@@ -7,6 +7,9 @@ export class Context {
 }
 
 export function parentPath(path: string): string {
+  if (path === "/") {
+    throw new Error("root context does not exist!");
+  }
   return String(path.split("/").slice(0, -1).join("/")) || "/";
 }
 
@@ -15,13 +18,24 @@ export class ContextRegistry {
 
   private readonly cache = new Map<string, Context>();
 
+  public loadAfterClear = false;
+
   public constructor() {
     this.add("/", {});
   }
 
   public add(path: string, context: Context): void {
+    console.log("adding", path);
     this.entries.set(path, context);
     this.cache.set(path, structuredClone(context));
+    this.loadAfterClear = true;
+  }
+
+  public clear() {
+    this.cache.clear();
+    this.entries.clear();
+    this.add("/", { name: "cleared" });
+    this.loadAfterClear = false;
   }
 
   public find(path: string): Context {

--- a/src/server/context-registry.ts
+++ b/src/server/context-registry.ts
@@ -18,24 +18,19 @@ export class ContextRegistry {
 
   private readonly cache = new Map<string, Context>();
 
-  public loadAfterClear = false;
-
   public constructor() {
     this.add("/", {});
   }
 
   public add(path: string, context: Context): void {
-    console.log("adding", path);
     this.entries.set(path, context);
     this.cache.set(path, structuredClone(context));
-    this.loadAfterClear = true;
   }
 
   public clear() {
     this.cache.clear();
     this.entries.clear();
-    this.add("/", { name: "cleared" });
-    this.loadAfterClear = false;
+    this.add("/", {});
   }
 
   public find(path: string): Context {

--- a/src/server/context-registry.ts
+++ b/src/server/context-registry.ts
@@ -27,12 +27,6 @@ export class ContextRegistry {
     this.cache.set(path, structuredClone(context));
   }
 
-  public clear() {
-    this.cache.clear();
-    this.entries.clear();
-    this.add("/", {});
-  }
-
   public find(path: string): Context {
     return this.entries.get(path) ?? this.find(parentPath(path));
   }

--- a/src/server/module-loader.ts
+++ b/src/server/module-loader.ts
@@ -79,7 +79,6 @@ export class ModuleLoader extends EventTarget {
 
     if (isRoot) {
       this.registry.clear();
-      this.contextRegistry.clear();
     }
 
     this.uncachedImport =

--- a/src/server/module-loader.ts
+++ b/src/server/module-loader.ts
@@ -125,10 +125,16 @@ export class ModuleLoader extends EventTarget {
     directory: string,
     file: Dirent,
   ) {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    const endpoint: ContextModule | Module = (await this.uncachedImport(
-      fullPath,
-    )) as ContextModule | Module;
+    let endpoint: ContextModule | Module = {};
+    try {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      endpoint = (await this.uncachedImport(fullPath)) as
+        | ContextModule
+        | Module;
+    } catch (error) {
+      debug("error loading %s: %s", fullPath, error);
+      return;
+    }
 
     if (file.name.includes("_.context")) {
       if (isContextModule(endpoint)) {

--- a/src/server/module-loader.ts
+++ b/src/server/module-loader.ts
@@ -109,6 +109,8 @@ export class ModuleLoader extends EventTarget {
   public async load(directory = ""): Promise<void> {
     const moduleKind = await determineModuleKind(this.basePath);
 
+    this.registry.clear();
+
     this.uncachedImport =
       moduleKind === "module" ? uncachedImport : uncachedRequire;
 

--- a/src/server/module-loader.ts
+++ b/src/server/module-loader.ts
@@ -52,6 +52,8 @@ export class ModuleLoader extends EventTarget {
   }
 
   public async watch(): Promise<void> {
+    debug("watching: %s", this.basePath);
+
     this.watcher = watch(`${this.basePath}/**/*.{js,mjs,ts,mts}`).on(
       "all",
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
@@ -70,7 +72,9 @@ export class ModuleLoader extends EventTarget {
     await this.watcher?.close();
   }
 
+  // eslint-disable-next-line max-statements
   public async load(directory = ""): Promise<void> {
+    debug("loading: %s", this.basePath);
     const moduleKind = await determineModuleKind(this.basePath);
 
     this.registry.clear();
@@ -114,6 +118,7 @@ export class ModuleLoader extends EventTarget {
 
     await Promise.all(imports);
     this.dispatchEvent(new Event("load"));
+    debug("finshed loading: %s", this.basePath);
   }
 
   private async loadEndpoint(

--- a/src/server/module-loader.ts
+++ b/src/server/module-loader.ts
@@ -137,7 +137,7 @@ export class ModuleLoader extends EventTarget {
 
     if (file.name.includes("_.context")) {
       if (isContextModule(endpoint)) {
-        this.contextRegistry.add(
+        this.contextRegistry.update(
           `/${directory.replaceAll("\\", "/")}`,
 
           // @ts-expect-error TS says Context has no constructable signatures but that's not true?

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -97,7 +97,7 @@ function castParameters(
 }
 
 export class Registry {
-  private readonly moduleTree = new ModuleTree();
+  private moduleTree = new ModuleTree();
 
   public get routes() {
     return this.moduleTree.routes;
@@ -109,6 +109,10 @@ export class Registry {
 
   public remove(url: string) {
     this.moduleTree.remove(url);
+  }
+
+  public clear() {
+    this.moduleTree = new ModuleTree();
   }
 
   public exists(method: HttpMethods, url: string) {

--- a/test/server/context-registry.test.ts
+++ b/test/server/context-registry.test.ts
@@ -35,6 +35,21 @@ describe("a context registry", () => {
     expect(registry.find("/goodbye/world")).toStrictEqual({});
   });
 
+  it("can be cleared", () => {
+    const helloContext = { name: "hello" };
+    const helloWorldContext = { name: "hello world" };
+
+    const registry = new ContextRegistry();
+
+    registry.add("/hello", helloContext);
+    registry.add("/hello/world", helloWorldContext);
+    registry.clear();
+
+    registry.add("/hello", helloContext);
+
+    expect(registry.find("/hello/world")).toEqual({ name: "hello" });
+  });
+
   it("updates an existing context by changing methods but not properties", () => {
     class SingleContext implements Context {
       public count = 0;

--- a/test/server/context-registry.test.ts
+++ b/test/server/context-registry.test.ts
@@ -35,21 +35,6 @@ describe("a context registry", () => {
     expect(registry.find("/goodbye/world")).toStrictEqual({});
   });
 
-  it("can be cleared", () => {
-    const helloContext = { name: "hello" };
-    const helloWorldContext = { name: "hello world" };
-
-    const registry = new ContextRegistry();
-
-    registry.add("/hello", helloContext);
-    registry.add("/hello/world", helloWorldContext);
-    registry.clear();
-
-    registry.add("/hello", helloContext);
-
-    expect(registry.find("/hello/world")).toEqual({ name: "hello" });
-  });
-
   it("updates an existing context by changing methods but not properties", () => {
     class SingleContext implements Context {
       public count = 0;

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -39,6 +39,38 @@ describe("a module loader", () => {
     });
   });
 
+  it("clears out an preexisting files", async () => {
+    const files: { [fileName: string]: string } = {
+      "hello.js": `
+      export function GET() {
+          return {
+              body: "hello"
+          };
+      }
+      `,
+      "package.json": '{ "type": "module" }',
+    };
+
+    await withTemporaryFiles(
+      files,
+      async (
+        basePath: string,
+        { remove }: { remove: (path: string) => Promise<void> },
+      ) => {
+        const registry: Registry = new Registry();
+        const loader: ModuleLoader = new ModuleLoader(basePath, registry);
+
+        await loader.load();
+
+        await remove("hello.js");
+
+        await loader.load();
+
+        expect(registry.exists("GET", "/hello")).toBe(false);
+      },
+    );
+  });
+
   it("updates the registry when a file is added", async () => {
     await withTemporaryFiles(
       { "package.json": '{ "type": "module" }' },

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -60,12 +60,7 @@ describe("a module loader", () => {
         { remove }: { remove: (path: string) => Promise<void> },
       ) => {
         const registry: Registry = new Registry();
-        const contextRegistry: ContextRegistry = new ContextRegistry();
-        const loader: ModuleLoader = new ModuleLoader(
-          basePath,
-          registry,
-          contextRegistry,
-        );
+        const loader: ModuleLoader = new ModuleLoader(basePath, registry);
 
         await loader.load();
 
@@ -75,8 +70,6 @@ describe("a module loader", () => {
         await loader.load();
 
         expect(registry.exists("GET", "/hello")).toBe(false);
-        expect(contextRegistry.find("/")).toEqual({ name: "root" });
-        expect(contextRegistry.find("/hello/world")).toEqual({ name: "root" });
       },
     );
   });

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -264,4 +264,31 @@ describe("a module loader", () => {
       expect(contextRegistry.find("/hello/world").value).toBe(101);
     });
   });
+
+  it("ignores a file that has a syntax error", async () => {
+    const files: { [fileName: string]: string } = {
+      "error.js": `
+      export function GET() {
+          syntax error
+      }
+      `,
+      "hello.js": `
+      export function GET() {
+          return {
+              body: "hello"
+          };
+      }
+      `,
+      "package.json": '{ "type": "module" }',
+    };
+
+    await withTemporaryFiles(files, async (basePath: string) => {
+      const registry: Registry = new Registry();
+      const loader: ModuleLoader = new ModuleLoader(basePath, registry);
+
+      await loader.load();
+
+      expect(registry.exists("GET", "/hello")).toBe(true);
+    });
+  });
 });

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -76,7 +76,7 @@ describe("a module loader", () => {
       { "package.json": '{ "type": "module" }' },
       async (
         basePath: string,
-        { add }: { add: (path: string, content: string) => void },
+        { add }: { add: (path: string, content: string) => Promise<void> },
       ) => {
         const registry: Registry = new Registry();
         const loader: ModuleLoader = new ModuleLoader(basePath, registry);
@@ -86,7 +86,7 @@ describe("a module loader", () => {
 
         expect(registry.exists("GET", "/late/addition")).toBe(false);
 
-        add(
+        await add(
           "late/addition.js",
           'export function GET() { return { body: "I\'m here now!" }; }',
         );

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -90,7 +90,7 @@ describe("a module loader", () => {
           "late/addition.js",
           'export function GET() { return { body: "I\'m here now!" }; }',
         );
-        await once(loader, "add");
+        await once(loader, "load");
 
         expect(registry.exists("GET", "/late/addition")).toBe(true);
 
@@ -108,7 +108,7 @@ describe("a module loader", () => {
       },
       async (
         basePath: string,
-        { remove }: { remove: (path: string) => void },
+        { remove }: { remove: (path: string) => Promise<void> },
       ) => {
         const registry: Registry = new Registry();
         const loader: ModuleLoader = new ModuleLoader(basePath, registry);
@@ -118,8 +118,9 @@ describe("a module loader", () => {
 
         expect(registry.exists("GET", "/delete-me")).toBe(true);
 
-        remove("delete-me.js");
-        await once(loader, "remove");
+        await remove("delete-me.js");
+
+        await once(loader, "load");
 
         expect(registry.exists("GET", "/delete-me")).toBe(false);
 

--- a/test/server/registry.test.ts
+++ b/test/server/registry.test.ts
@@ -20,6 +20,22 @@ describe("a registry", () => {
     expect(registry.exists("GET", "/goodbye")).toBe(false);
   });
 
+  it("can be cleared", () => {
+    const registry = new Registry();
+
+    registry.add("/hello", {
+      async GET() {
+        await Promise.resolve("noop");
+
+        return { body: "hello", headers: {}, status: 200 };
+      },
+    });
+
+    registry.clear();
+
+    expect(registry.exists("GET", "/hello")).toBe(false);
+  });
+
   it.todo("returns debug information if path does not exist");
 
   it("returns a function matching the URL and request method", async () => {


### PR DESCRIPTION
Fixes #835 

When any file is touched, the entire app is reloaded. This is necessary because any file that imports the file that was changed (directly or indirectly) needs to be reloaded.

I'm a bit concerned this is going to cause performance problems on large codebases, but we'll see. Ideally, instead of reloading everything, we would trace dependencies and only reload the files that need to be reloaded. 