### PR TITLE
expand .json() to include text/json and XML; fixes #918

### DIFF
--- a/.changeset/hungry-emus-hope.md
+++ b/.changeset/hungry-emus-hope.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+expand the .json() shortcut to include variations of JSON and XML content types

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,9 +111,9 @@ The `$.response` object is used to build a valid response for the URL and reques
 - `.random()` returns random data, using `examples` and other metadata from the OpenAPI document.
 - `.header(name, value)` adds a response header. It will only show up when a response header is expected and you haven't already provided it.
 - `.match(contentType, content)` is used to return content which matches the content type. If the API is intended to serve one of multiple content types, depending on the client's `Accepts:` header, you can chain multiple `match()` calls.
-- `.json(content)` is shorthand for `.match("application/json", content)`
-- `.text(content)` is shorthand for `.match("text/plain", content)`
-- `.html(content)` is shorthand for `.match("text/html", content)`
+  - `.json(content)`, `.text(content)`, `.html(content)`, and `.xml(content)` are shorthands for the `match()` function, e.g. `.text(content)` is shorthand for `.match("text/plain", content)`.
+  - if the content type is XML, you can pass a JSON object, and Counterfact will automatically convert it to XML for you
+  - The `.json()` shortcut handles both JSON and XML.
 
 You can build a response by chaining one or more of these functions, e.g.
 

--- a/src/server/response-builder.ts
+++ b/src/server/response-builder.ts
@@ -72,7 +72,11 @@ export function createResponseBuilder(
       },
 
       json(this: ResponseBuilder, body: unknown) {
-        return this.match("application/json", body);
+        return this.match("application/json", body)
+          .match("text/json", body)
+          .match("text/x-json", body)
+          .match("application/xml", body)
+          .match("text/xml", body);
       },
 
       match(

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -99,7 +99,7 @@ type GenericResponseBuilderInner<
     ? never
     : HeaderFunction<Response>;
   html: MaybeShortcut<"text/html", Response>;
-  json: MaybeShortcut<"application/json", Response>;
+  json: MaybeShortcut<"application/json" | "text/json" | "text/x-json" | "application/xml" | "text/xml", Response>;
   match: [keyof Response["content"]] extends [never]
     ? never
     : MatchFunction<Response>;

--- a/test/server/response-builder.test.ts
+++ b/test/server/response-builder.test.ts
@@ -38,6 +38,16 @@ describe("a response builder", () => {
     expect(response?.content).toStrictEqual([
       { body: "hello", type: "text/plain" },
       { body: { hello: "world" }, type: "application/json" },
+      { body: { hello: "world" }, type: "text/json" },
+      { body: { hello: "world" }, type: "text/x-json" },
+      {
+        body: "<root><hello>world</hello></root>",
+        type: "application/xml",
+      },
+      {
+        body: "<root><hello>world</hello></root>",
+        type: "text/xml",
+      },
       { body: "<h1>Hello World</h1>", type: "text/html" },
       {
         body: "<root><hello>world</hello></root>",


### PR DESCRIPTION
.json() now handles:
  - application/json
  - text/json
  - text/x-json
  - application/xml
  - text/xml

I decided to roll up XML into `.json()` because Counterfact automatically converts a JSON object to XML. This will also remove a WTF when working with the pet store example, as it spares users from explicitly thinking about returning an XML response. 