### PR TITLE
revert a type change that made things worse

### DIFF
--- a/.changeset/yellow-oranges-promise.md
+++ b/.changeset/yellow-oranges-promise.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+reverted type change for .json() -- it had unintended consequences

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,9 +111,10 @@ The `$.response` object is used to build a valid response for the URL and reques
 - `.random()` returns random data, using `examples` and other metadata from the OpenAPI document.
 - `.header(name, value)` adds a response header. It will only show up when a response header is expected and you haven't already provided it.
 - `.match(contentType, content)` is used to return content which matches the content type. If the API is intended to serve one of multiple content types, depending on the client's `Accepts:` header, you can chain multiple `match()` calls.
-  - `.json(content)`, `.text(content)`, `.html(content)`, and `.xml(content)` are shorthands for the `match()` function, e.g. `.text(content)` is shorthand for `.match("text/plain", content)`.
-  - if the content type is XML, you can pass a JSON object, and Counterfact will automatically convert it to XML for you
-  - The `.json()` shortcut handles both JSON and XML.
+- `.json(content)` is shorthand for `.match("application/json", content)`
+- `.text(content)` is shorthand for `.match("text/plain", content)`
+- `.html(content)` is shorthand for `.match("text/html", content)`
+- `.xml(content)` is shorthand for `.match("application/xml", content)`
 
 You can build a response by chaining one or more of these functions, e.g.
 

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -99,7 +99,7 @@ type GenericResponseBuilderInner<
     ? never
     : HeaderFunction<Response>;
   html: MaybeShortcut<"text/html", Response>;
-  json: MaybeShortcut<"application/json" | "text/json" | "text/x-json" | "application/xml" | "text/xml", Response>;
+  json: MaybeShortcut<"application/json", Response>;
   match: [keyof Response["content"]] extends [never]
     ? never
     : MatchFunction<Response>;
@@ -107,7 +107,7 @@ type GenericResponseBuilderInner<
     ? never
     : RandomFunction<Response>;
   text: MaybeShortcut<"text/plain", Response>;
-  xml: MaybeShortcut<"application/xml" | "text/xml", Response>;
+  xml: MaybeShortcut<"application/xml", Response>;
 }>;
 
 type GenericResponseBuilder<


### PR DESCRIPTION
I didn't realize until after release, but my latest change broke type checking on the argument of `.json()` and `.xml()`. 

To make the type check work I think I'm going to have to change MaybeShortcut so that ContentType is an array. I'm also going to have to change this line.

```ts
content: NeverIfEmpty<Omit<Response["content"], ContentType>>;
```

If `Response["content"]` is an array, I'll have to change `Omit` to an `OmitAll` function that loops over the arrya. 