### PR TITLE
fix(server): Update context find logic in context-registry

### DIFF
--- a/.changeset/wet-pumas-wash.md
+++ b/.changeset/wet-pumas-wash.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Update context-registry find logic for bug with mixed path casing

--- a/src/server/context-registry.ts
+++ b/src/server/context-registry.ts
@@ -21,13 +21,26 @@ export class ContextRegistry {
     this.add("/", {});
   }
 
+  private getContextIgnoreCase(map: Map<string, Context>, key: string) {
+    const lowerCaseKey = key.toLowerCase();
+    for (const currentKey of map.keys()) {
+      if (currentKey.toLowerCase() === lowerCaseKey) {
+        return map.get(currentKey);
+      }
+    }
+    return undefined;
+  }
+
   public add(path: string, context: Context): void {
     this.entries.set(path, context);
     this.cache.set(path, structuredClone(context));
   }
 
   public find(path: string): Context {
-    return this.entries.get(path) ?? this.find(parentPath(path));
+    return (
+      this.getContextIgnoreCase(this.entries, path) ??
+      this.find(parentPath(path))
+    );
   }
 
   // eslint-disable-next-line max-statements

--- a/test/server/context-registry.test.ts
+++ b/test/server/context-registry.test.ts
@@ -25,6 +25,16 @@ describe("a context registry", () => {
     expect(registry.find("/hello/world")).toBe(helloContext);
   });
 
+  it("finds a context at a parent path with alternate casing", () => {
+    const helloContext = { name: "hello" };
+
+    const registry = new ContextRegistry();
+
+    registry.add("/hello", helloContext);
+
+    expect(registry.find("/Hello/world")).toBe(helloContext);
+  });
+
   it("returns an empty object when there is no matching context", () => {
     const helloContext = { name: "hello" };
 


### PR DESCRIPTION
If an OpenApi spec has multiple paths that share the same root, but different child paths, if those parent paths are a mixture of cases, the context registry stores the contexts for the paths once (which is correct), but the `.find` operation in `context-registry` expects the map key to match the path.

For example, suppose a spec has paths of `myPets/vaccinations` as well as `mypets/visits`. Now suppose the user has created a `_.context.ts` file at `routes/myPets/_.context.ts`. When a request comes in for `myPets/vaccinations` it will find the custom context, but when the request comes in for `mypets/visits` it will fail to find the custom context because it will look for a parent path of `mypets` and nothing exists in the ContextRegistry.entries for that key.

This PR fixes the path find logic.