### PR TITLE
fix(server): Add support for directories with multiple wildcard children

### DIFF
--- a/.changeset/rich-bees-applaud.md
+++ b/.changeset/rich-bees-applaud.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Fixes logic in module-tree when a path has multiple wildcard children at the same position

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -251,7 +251,7 @@ export class Dispatcher {
       path = path.replace(new RegExp(this.openApiDocument.basePath, "iu"), "");
     }
 
-    const { matchedPath } = this.registry.handler(path);
+    const { matchedPath } = this.registry.handler(path, method);
     const operation = this.operationForPathAndMethod(matchedPath, method);
 
     const response = await this.registry.endpoint(

--- a/src/server/module-tree.ts
+++ b/src/server/module-tree.ts
@@ -187,12 +187,12 @@ export class ModuleTree {
       );
     }
 
-    const wildcardDirectory = Object.values(directory.directories).find(
+    const wildcardDirectories = Object.values(directory.directories).filter(
       (subdirectory) => subdirectory.isWildcard,
     );
 
-    if (wildcardDirectory) {
-      return this.matchWithinDirectory(
+    for (const wildcardDirectory of wildcardDirectories) {
+      const match = this.matchWithinDirectory(
         wildcardDirectory,
         remainingSegments,
         {
@@ -201,6 +201,10 @@ export class ModuleTree {
         },
         `${matchedPath}/${wildcardDirectory.rawName}`,
       );
+
+      if (match !== undefined) {
+        return match;
+      }
     }
 
     return undefined;

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -111,11 +111,11 @@ export class Registry {
   }
 
   public exists(method: HttpMethods, url: string) {
-    return Boolean(this.handler(url).module?.[method]);
+    return Boolean(this.handler(url, method).module?.[method]);
   }
 
-  public handler(url: string) {
-    const match = this.moduleTree.match(url);
+  public handler(url: string, method: string) {
+    const match = this.moduleTree.match(url, method);
 
     return {
       matchedPath: match?.matchedPath ?? "",
@@ -133,7 +133,7 @@ export class Registry {
       query?: { [key: string]: string };
     } = {},
   ) {
-    const handler = this.handler(url);
+    const handler = this.handler(url, httpRequestMethod);
 
     debug("handler for %s: %o", url, handler);
 


### PR DESCRIPTION
Updates the logic in `module-tree.ts` to support a path that has multiple children that are wildcards at the same segment position. E.g.:

`/myPets/{petName}/health`
`/myPets/{petId}/records`

The PR also updates the logic in `module-tree.ts` to support a path that has multiple wildcard files at the same ending segment but with different methods. E.g.:

`/myPets/health/{id}` - GET
`/myPets/health/{enableDisable}` - PUT