### PR TITLE
feat(server): Update JSONSchemaFaker not to create fake object properties

### DIFF
--- a/.changeset/selfish-numbers-matter.md
+++ b/.changeset/selfish-numbers-matter.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Updates JSONSchemaFaker to have the fillProperties option false so it will not make up fake object properties

--- a/src/server/response-builder.ts
+++ b/src/server/response-builder.ts
@@ -8,6 +8,7 @@ JSONSchemaFaker.option("minItems", 0);
 JSONSchemaFaker.option("maxItems", 20);
 JSONSchemaFaker.option("failOnInvalidTypes", false);
 JSONSchemaFaker.option("failOnInvalidFormat", false);
+JSONSchemaFaker.option("fillProperties", false);
 
 function convertToXmlIfNecessary(
   type: string,

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,6 +1,7 @@
 import { JSONSchemaFaker, type Schema } from "json-schema-faker";
 
 JSONSchemaFaker.option("useExamplesValue", true);
+JSONSchemaFaker.option("fillProperties", false);
 
 export class Tools {
   private readonly headers: { [key: string]: string[] | string | undefined };


### PR DESCRIPTION
Updates the default settings for JSONSchemaFaker so the `fillProperties` setting is false. This prevents the schema faker from creating random properties in the result objects.