### PR TITLE
path parameters are always strings

### DIFF
--- a/.changeset/long-bulldogs-stare.md
+++ b/.changeset/long-bulldogs-stare.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+also cast numbers (non-integers) and booleans to the right types at runtime

--- a/.changeset/two-fans-collect.md
+++ b/.changeset/two-fans-collect.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+correct runtime type of parameters for Swagger v2 (fixes #1116)

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -84,11 +84,11 @@ export class Dispatcher {
     }
 
     for (const parameter of parameters) {
-      if (parameter.schema !== undefined) {
+      const type = parameter.schema?.type ?? parameter?.type;
+
+      if (type !== undefined) {
         types[parameter.in][parameter.name] =
-          parameter.schema.type === "integer"
-            ? "number"
-            : parameter.schema.type;
+          type === "integer" ? "number" : type;
       }
     }
 

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -79,17 +79,30 @@ interface NormalizedCounterfactResponseObject {
   status?: number;
 }
 
-function castParameters(
-  parameters: { [key: string]: number | string },
-  parameterTypes?: { [key: string]: string },
-) {
-  const copy: { [key: string]: number | string } = { ...parameters };
+function castParameter(value: string, type: string) {
+  if (type === "integer") {
+    return Number.parseInt(value);
+  }
 
-  Object.entries(copy).forEach(([key, value]) => {
-    copy[key] =
-      parameterTypes?.[key] === "number"
-        ? Number.parseInt(value as string, 10)
-        : value;
+  if (type === "number") {
+    return Number.parseFloat(value);
+  }
+
+  if (type === "boolean") {
+    return value === "true";
+  }
+
+  return value;
+}
+
+function castParameters(
+  parameters: { [key: string]: string } = {},
+  parameterTypes: { [key: string]: string } = {},
+) {
+  const copy: { [key: string]: boolean | number | string } = {};
+
+  Object.entries(parameters).forEach(([key, value]) => {
+    copy[key] = castParameter(value, parameterTypes?.[key] ?? "string");
   });
 
   return copy;

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -22,16 +22,16 @@ interface RequestData {
     username?: string;
   };
   context: unknown;
-  headers: { [key: string]: number | string };
+  headers: { [key: string]: number | string | boolean };
   matchedPath?: string;
-  path?: { [key: string]: number | string };
+  path?: { [key: string]: number | string | boolean };
   proxy: (url: string) => Promise<{
     body: string;
     contentType: string;
     headers: { [key: string]: string };
     status: number;
   }>;
-  query: { [key: string]: number | string };
+  query: { [key: string]: number | string | boolean };
   response: ResponseBuilderFactory;
   tools: Tools;
 }
@@ -79,7 +79,11 @@ interface NormalizedCounterfactResponseObject {
   status?: number;
 }
 
-function castParameter(value: string, type: string) {
+function castParameter(value: string | number | boolean, type: string) {
+  if (typeof value !== "string") {
+    return value;
+  }
+
   if (type === "integer") {
     return Number.parseInt(value);
   }
@@ -96,7 +100,7 @@ function castParameter(value: string, type: string) {
 }
 
 function castParameters(
-  parameters: { [key: string]: string } = {},
+  parameters: { [key: string]: string | number | boolean } = {},
   parameterTypes: { [key: string]: string } = {},
 ) {
   const copy: { [key: string]: boolean | number | string } = {};

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -226,6 +226,7 @@ interface OpenApiParameters {
   schema?: {
     type: string;
   };
+  type?: "string" | "number" | "integer" | "boolean";
 }
 
 interface OpenApiOperation {

--- a/test/server/dispatcher.test.ts
+++ b/test/server/dispatcher.test.ts
@@ -672,6 +672,7 @@ describe("a dispatcher", () => {
       // @ts-expect-error - not obvious how to make TS happy here, and it's just a unit test
       GET({ headers, path, query, response }) {
         return response["200"]?.text({
+          booleanInHeader: headers.booleanInHeader,
           integerInPath: path?.integerInPath,
           numberInHeader: headers.numberInHeader,
           numberInQuery: query.numberInQuery,
@@ -713,6 +714,11 @@ describe("a dispatcher", () => {
                 name: "stringInHeader",
                 type: "string",
               },
+              {
+                in: "header",
+                name: "booleanInHeader",
+                type: "boolean",
+              },
             ],
 
             responses: {
@@ -743,6 +749,7 @@ describe("a dispatcher", () => {
       headers: {
         numberInHeader: "5",
         stringInHeader: "6",
+        booleanInHeader: "true",
       },
 
       method: "GET",
@@ -758,6 +765,7 @@ describe("a dispatcher", () => {
     });
 
     expect(htmlResponse.body).toStrictEqual({
+      booleanInHeader: true,
       integerInPath: 1,
       numberInHeader: 5,
       numberInQuery: 3,

--- a/test/server/dispatcher.test.ts
+++ b/test/server/dispatcher.test.ts
@@ -665,6 +665,108 @@ describe("a dispatcher", () => {
     });
   });
 
+  it("converts query, path, and header parameters to numbers if necessary (Swagger v2)", async () => {
+    const registry = new Registry();
+
+    registry.add("/a/{integerInPath}/{stringInPath}", {
+      // @ts-expect-error - not obvious how to make TS happy here, and it's just a unit test
+      GET({ headers, path, query, response }) {
+        return response["200"]?.text({
+          integerInPath: path?.integerInPath,
+          numberInHeader: headers.numberInHeader,
+          numberInQuery: query.numberInQuery,
+          stringInHeader: headers.stringInHeader,
+          stringInPath: path?.stringInPath,
+          stringInQuery: query.stringInQuery,
+        });
+      },
+    });
+
+    const openApiDocument: OpenApiDocument = {
+      paths: {
+        "/a/{integerInPath}/{stringInPath}": {
+          get: {
+            parameters: [
+              {
+                in: "path",
+                name: "integerInPath",
+                type: "integer",
+              },
+              { in: "path", name: "stringInPath", type: "string" },
+              {
+                in: "query",
+                name: "numberInQuery",
+                type: "number",
+              },
+              {
+                in: "query",
+                name: "stringInQuery",
+                type: "string",
+              },
+              {
+                in: "header",
+                name: "numberInHeader",
+                type: "number",
+              },
+              {
+                in: "header",
+                name: "stringInHeader",
+                type: "string",
+              },
+            ],
+
+            responses: {
+              200: {
+                content: {
+                  "application/json": {
+                    schema: {
+                      integerInPath: "number",
+                      stringInPath: "string",
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const dispatcher = new Dispatcher(
+      registry,
+      new ContextRegistry(),
+      openApiDocument,
+    );
+    const htmlResponse = await dispatcher.request({
+      body: "",
+
+      headers: {
+        numberInHeader: "5",
+        stringInHeader: "6",
+      },
+
+      method: "GET",
+
+      path: "/a/1/2",
+
+      query: {
+        numberInQuery: "3",
+        stringInQuery: "4",
+      },
+
+      req: { path: "/a/1/2" },
+    });
+
+    expect(htmlResponse.body).toStrictEqual({
+      integerInPath: 1,
+      numberInHeader: 5,
+      numberInQuery: 3,
+      stringInHeader: "6",
+      stringInPath: "2",
+      stringInQuery: "4",
+    });
+  });
+
   it("attaches the root produces array to an operation", () => {
     const registry = new Registry();
 


### PR DESCRIPTION
Fixes #1116 

Counterfact looks at OpenAPI spec to determine the types of parameters in the query, path, or headers and make sure they are parsed to the correct type at runtime (string, number, or boolean -- we don't support arrays yet). 

When using OpenAPI / Swagger v2, the types of parameters are in the `type` property rather than `schema.type`. Counterfact wasn't looking for the `type` property so everything was being left as strings. 

Also, it didn't make a distinction between `number` and `integer`, casting all numbers to integers. With this change integers are parsed with `parseInt()` and numbers are parsed with `parseFloat()`. 

Also booleans were not parsed. Now the string "true" is parsed as `true`; any other string is `false`. 