### PR TITLE
feat: add openApiDocument to module-loader Context #968

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -64,6 +64,7 @@ export async function counterfact(config: Config) {
     compiledPathsDirectory,
     registry,
     contextRegistry,
+    await loadOpenApiDocument(config.openApiPath),
   );
 
   const middleware = koaMiddleware(dispatcher, config);


### PR DESCRIPTION
I *think* this change passes the openApiDocument over from the `app.ts` file to the `module-loader.ts`. Wasn't 100% sure how to test this change locally though, so I'd love to do that if someone can help me wrap my head around it. 