### PR TITLE
feat: Add alwaysFakeOptionals command line option

### DIFF
--- a/.changeset/green-dodos-develop.md
+++ b/.changeset/green-dodos-develop.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+Add alwaysFakeOptionals option

--- a/bin/counterfact.js
+++ b/bin/counterfact.js
@@ -135,6 +135,7 @@ async function main(source, destination) {
   const swaggerUrl = `${url}/counterfact/swagger/`;
 
   const config = {
+    alwaysFakeOptionals: options.alwaysFakeOptionals,
     basePath,
 
     generate: {
@@ -267,6 +268,10 @@ program
     "--prefix <string>",
     "base path from which routes will be served (e.g. /api/v1)",
     "",
+  )
+  .option(
+    "--always-fake-optionals",
+    "random responses will include optional fields",
   )
   .action(main)
   .parse(process.argv);

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,6 +52,7 @@ export async function counterfact(config: Config) {
     registry,
     contextRegistry,
     await loadOpenApiDocument(config.openApiPath),
+    config,
   );
 
   const transpiler = new Transpiler(

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,4 +1,5 @@
 export interface Config {
+  alwaysFakeOptionals: boolean;
   basePath: string;
   generate: {
     routes: boolean;

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -13,6 +13,7 @@ import type {
 import { createResponseBuilder } from "./response-builder.js";
 import { Tools } from "./tools.js";
 import type { OpenApiOperation, OpenApiParameters } from "./types.ts";
+import type { Config } from "./config.js";
 
 const debug = createDebugger("counterfact:server:dispatcher");
 
@@ -56,15 +57,19 @@ export class Dispatcher {
 
   public fetch: typeof fetch;
 
+  public config?: Config; // Add config property
+
   public constructor(
     registry: Registry,
     contextRegistry: ContextRegistry,
     openApiDocument?: OpenApiDocument,
+    config?: Config,
   ) {
     this.registry = registry;
     this.contextRegistry = contextRegistry;
     this.openApiDocument = openApiDocument;
     this.fetch = fetch;
+    this.config = config;
   }
 
   private parameterTypes(
@@ -295,7 +300,10 @@ export class Dispatcher {
       query,
 
       // @ts-expect-error - Might be pushing the limits of what TypeScript can do here
-      response: createResponseBuilder(operation ?? { responses: {} }),
+      response: createResponseBuilder(
+        operation ?? { responses: {} },
+        this.config,
+      ), // Pass config
 
       tools: new Tools({ headers }),
     });

--- a/src/server/response-builder.ts
+++ b/src/server/response-builder.ts
@@ -2,6 +2,7 @@ import { JSONSchemaFaker } from "json-schema-faker";
 
 import { jsonToXml } from "./json-to-xml.js";
 import type { OpenApiOperation, ResponseBuilder } from "./types.ts";
+import type { Config } from "./config.js";
 
 JSONSchemaFaker.option("useExamplesValue", true);
 JSONSchemaFaker.option("minItems", 0);
@@ -48,6 +49,7 @@ function unknownStatusCodeResponse(statusCode: number | undefined) {
 
 export function createResponseBuilder(
   operation: OpenApiOperation,
+  config?: Config,
 ): ResponseBuilder {
   return new Proxy({} as ResponseBuilder, {
     get: (target, statusCode: string) => ({
@@ -104,6 +106,11 @@ export function createResponseBuilder(
       },
 
       random(this: ResponseBuilder) {
+        if (config?.alwaysFakeOptionals) {
+          JSONSchemaFaker.option("alwaysFakeOptionals", true);
+          JSONSchemaFaker.option("fixedProbabilities", true);
+          JSONSchemaFaker.option("optionalsProbability", 1.0);
+        }
         if (operation.produces) {
           return this.randomLegacy();
         }


### PR DESCRIPTION
Here is a first take on adding the --always-fake-optionals command line option. At first I tried to add the negative case where not having this true would mean optionals are undefined, but that's not a valid test since sometimes JSONSchemaFaker provides random optionals and sometimes not (which is the allowed behavior). So I can't test the default behavior, but we should expect that turning them on is always true. Again, my trouble here is, this isn't a deterministic test since sometimes and optional can be faked even without the switch on. So it could have a false positive, but should never be negative.

Lastly, I threw in there the other two options of `fixedProbabilities` and `optionalsProbability` because from reading it seems those should be set for this to fully work. It was unclear to me if setting `alwaysFakeOptionals` already sets both of those others, but after reading various GitHub issues in the JSF repo I just opted to explicitly turn them all on.