### PR TITLE
feat: mock service worker handler ability

### DIFF
--- a/.changeset/dry-socks-kiss.md
+++ b/.changeset/dry-socks-kiss.md
@@ -1,0 +1,5 @@
+---
+"counterfact": minor
+---
+
+Add Mock Service Worker handler capability

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.3.0",
   "description": "a library for building a fake REST API for testing",
   "type": "module",
-  "main": "./src/server/counterfact.js",
-  "exports": "./src/server/counterfact.js",
-  "types": "./src/counterfact.d.ts",
+  "main": "./dist/app.js",
+  "exports": "./dist/app.js",
+  "types": "./dist/server/types.d.ts",
   "author": "Patrick McElhaney <pmcelhaney@gmail.com> (https://patrickmcelhaney.com)",
   "license": "MIT",
   "repository": "github:pmcelhaney/counterfact",
@@ -107,5 +107,6 @@
     "prettier": "3.5.3",
     "recast": "0.23.11",
     "typescript": "5.8.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises";
+import fs, { rm } from "node:fs/promises";
 import nodePath from "node:path";
 
 import { dereference } from "@apidevtools/json-schema-ref-parser";
@@ -9,7 +9,11 @@ import { startRepl } from "./repl/repl.js";
 import type { Config } from "./server/config.js";
 import { ContextRegistry } from "./server/context-registry.js";
 import { createKoaApp } from "./server/create-koa-app.js";
-import { Dispatcher, type OpenApiDocument } from "./server/dispatcher.js";
+import {
+  Dispatcher,
+  DispatcherRequest,
+  type OpenApiDocument,
+} from "./server/dispatcher.js";
 import { koaMiddleware } from "./server/koa-middleware.js";
 import { ModuleLoader } from "./server/module-loader.js";
 import { Registry } from "./server/registry.js";
@@ -17,7 +21,23 @@ import { Transpiler } from "./server/transpiler.js";
 import { CodeGenerator } from "./typescript-generator/code-generator.js";
 import { readFile } from "./util/read-file.js";
 
-async function loadOpenApiDocument(source: string) {
+type MswHandlerMap = {
+  [key: string]: (request: any) => Promise<any>;
+};
+const allowedMethods = [
+  "all",
+  "head",
+  "get",
+  "post",
+  "put",
+  "delete",
+  "patch",
+  "options",
+] as const;
+
+export type MockRequest = DispatcherRequest & { rawPath: string };
+
+export async function loadOpenApiDocument(source: string) {
   try {
     const text = await readFile(source);
 
@@ -27,6 +47,73 @@ async function loadOpenApiDocument(source: string) {
   } catch {
     return undefined;
   }
+}
+
+const mswHandlers: MswHandlerMap = {};
+
+export async function handleMswRequest(request: MockRequest) {
+  const { method, rawPath } = request;
+  const handler = mswHandlers[`${method}:${rawPath}`];
+  if (handler) {
+    return handler(request);
+  }
+  console.warn(`No handler found for ${method} ${rawPath}`);
+  return { error: `No handler found for ${method} ${rawPath}`, status: 404 };
+}
+
+export async function createMswHandlers(
+  config: Config,
+  ModuleLoaderClass = ModuleLoader,
+) {
+  // TODO: For some reason the Vitest Custom Commands needed by Vitest Browser mode fail on fs.readFile when they are called from the nested loadOpenApiDocument function.
+  // If we "pre-read" the file here it works. This is a workaround to avoid the issue.
+  const _ = await fs.readFile(config.openApiPath);
+  const openApiDocument = await loadOpenApiDocument(config.openApiPath);
+  if (openApiDocument === undefined) {
+    throw new Error(
+      `Could not load OpenAPI document from ${config.openApiPath}`,
+    );
+  }
+  const modulesPath = config.basePath;
+  const compiledPathsDirectory = nodePath
+    .join(modulesPath, ".cache")
+    .replaceAll("\\", "/");
+
+  const registry = new Registry();
+  const contextRegistry = new ContextRegistry();
+  const dispatcher = new Dispatcher(
+    registry,
+    contextRegistry,
+    openApiDocument,
+    config,
+  );
+  const moduleLoader = new ModuleLoaderClass(
+    compiledPathsDirectory,
+    registry,
+    contextRegistry,
+  );
+  await moduleLoader.load();
+  const routes = registry.routes;
+  const handlers = routes.flatMap((route) => {
+    const { methods, path } = route;
+
+    return Object.keys(methods)
+      .filter((method) =>
+        allowedMethods.includes(
+          method.toLowerCase() as (typeof allowedMethods)[number],
+        ),
+      )
+      .map((method) => {
+        const lowerMethod = method.toLowerCase();
+        const apiPath = `${openApiDocument.basePath ?? ""}${path.replaceAll("{", ":").replaceAll("}", "")}`;
+        const handler = async (request: MockRequest) => {
+          return await dispatcher.request(request);
+        };
+        mswHandlers[`${method}:${apiPath}`] = handler;
+        return { method: lowerMethod, path: apiPath };
+      });
+  });
+  return handlers;
 }
 
 export async function counterfact(config: Config) {

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -47,6 +47,25 @@ export interface OpenApiDocument {
   produces?: string[];
 }
 
+export type DispatcherRequest = {
+  auth?: {
+    password?: string;
+    username?: string;
+  };
+  body: unknown;
+  headers: {
+    [key: string]: string;
+  };
+  method: HttpMethods;
+  path: string;
+  query: {
+    [key: string]: string;
+  };
+  req: {
+    path?: string;
+  };
+};
+
 export class Dispatcher {
   public registry: Registry;
 
@@ -220,24 +239,7 @@ export class Dispatcher {
     path,
     query,
     req,
-  }: {
-    auth?: {
-      password?: string;
-      username?: string;
-    };
-    body: unknown;
-    headers: {
-      [key: string]: string;
-    };
-    method: HttpMethods;
-    path: string;
-    query: {
-      [key: string]: string;
-    };
-    req: {
-      path?: string;
-    };
-  }): Promise<CounterfactResponseObject> {
+  }: DispatcherRequest): Promise<CounterfactResponseObject> {
     debug(`request: ${method} ${path}`);
 
     // If the incoming path includes the base path, remove it

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -1,0 +1,97 @@
+// import { describe, it, expect } from "@jest/globals";
+import * as app from "../src/app";
+
+// Use the same HttpMethods type as in app.ts
+const httpMethod: any = "get";
+
+// Minimal valid mock Config
+const mockConfig = {
+  openApiPath: "foo.yaml",
+  basePath: ".",
+  port: 1234,
+  alwaysFakeOptionals: false,
+  generate: { routes: false, types: false },
+  proxyPaths: new Map(),
+  proxyUrl: "",
+  startRepl: false,
+  startServer: false,
+  watch: { routes: false, types: false },
+  routePrefix: "",
+};
+
+// Minimal valid mock MockRequest
+const mockRequest = {
+  method: httpMethod,
+  rawPath: "/foo",
+  body: undefined,
+  headers: {},
+  path: "/foo",
+  query: {},
+  req: {},
+};
+
+class MockModuleLoader {
+  private registry: any;
+  constructor(basePath: string, registry: any, contextRegistry: any) {
+    this.registry = registry;
+  }
+  async load() {
+    // Register a mock route in the registry for GET /foo
+    this.registry.add("/foo", {
+      get: async () => ({ ok: true }),
+    });
+  }
+  async watch() {}
+  async stopWatching() {}
+}
+
+describe("handleMswRequest", () => {
+  it("returns 404 if no handler exists", async () => {
+    const result = await (app as any).handleMswRequest(mockRequest);
+    expect(result).toEqual({
+      error: "No handler found for get /foo",
+      status: 404,
+    });
+  });
+
+  it("calls the correct handler if present", async () => {
+    await (app as any).createMswHandlers(
+      {
+        ...mockConfig,
+        openApiPath: "openapi-example.yaml",
+      },
+      MockModuleLoader,
+    );
+    const result = await (app as any).handleMswRequest(mockRequest);
+    expect(result).toBeDefined();
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("createMswHandlers", () => {
+  it("throws if openApiDocument is undefined", async () => {
+    await expect(
+      (app as any).createMswHandlers(
+        {
+          ...mockConfig,
+          openApiPath: "nonexistent.yaml",
+        },
+        MockModuleLoader,
+      ),
+    ).rejects.toThrow();
+  });
+
+  it("returns handlers for valid openApiDocument", async () => {
+    const handlers = await (app as any).createMswHandlers(
+      {
+        ...mockConfig,
+        openApiPath: "openapi-example.yaml",
+      },
+      MockModuleLoader,
+    );
+    expect(Array.isArray(handlers)).toBe(true);
+    expect(handlers.length).toBeGreaterThan(0);
+    expect(handlers[0]).toHaveProperty("method");
+    expect(handlers[0]).toHaveProperty("path");
+  });
+});


### PR DESCRIPTION
Adds two new functions to the app: 

`createMswHandlers`
and 
`handleMswRequest`

These can be used to generate a set of mock service worker handlers that allow MSW to hand off requests to Counterfact. 

Presently this is somewhat narrowly written with Vitest Browser mode in mind where Vitest communicates with Counterfact through the Custom Commands concept where there is a bridge between the browser and node. A future update might allow the Counterfact Dispatcher to run entirely in the browser and eliminate the need for the two stage setup.