### PR TITLE
feat: Add CLI option to build cache

### DIFF
--- a/.changeset/thick-rocks-clean.md
+++ b/.changeset/thick-rocks-clean.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Add buildCache CLI option

--- a/bin/counterfact.js
+++ b/bin/counterfact.js
@@ -111,7 +111,7 @@ async function main(source, destination) {
 
   // If no action-related option is provided, default to all options
 
-  const actions = ["repl", "serve", "watch", "generate"];
+  const actions = ["repl", "serve", "watch", "generate", "buildCache"];
   if (
     !Object.keys(options).some((argument) =>
       actions.some((action) => argument.startsWith(action)),
@@ -143,13 +143,15 @@ async function main(source, destination) {
         options.generate ||
         options.generateRoutes ||
         options.watch ||
-        options.watchRoutes,
+        options.watchRoutes ||
+        options.buildCache,
 
       types:
         options.generate ||
         options.generateTypes ||
         options.watch ||
-        options.watchTypes,
+        options.watchTypes ||
+        options.buildCache,
     },
 
     openApiPath: source,
@@ -159,6 +161,7 @@ async function main(source, destination) {
     routePrefix: options.prefix,
     startRepl: options.repl,
     startServer: options.serve,
+    buildCache: options.buildCache || false,
 
     watch: {
       routes: options.watch || options.watchRoutes,
@@ -262,6 +265,7 @@ program
   .option("--watch-types", "generate + watch types for changes")
   .option("--watch-routes", "generate + watch routes for changes")
   .option("-s, --serve", "start the server")
+  .option("-b, --build-cache", "builds the cache of compiled routes and types")
   .option("-r, --repl", "start the REPL")
   .option("--proxy-url <string>", "proxy URL")
   .option(

--- a/src/app.ts
+++ b/src/app.ts
@@ -164,6 +164,7 @@ export async function counterfact(config: Config) {
       startRepl: shouldStartRepl,
       startServer,
       watch,
+      buildCache,
     } = options;
 
     if (generate.routes || generate.types) {
@@ -188,6 +189,10 @@ export async function counterfact(config: Config) {
       httpTerminator = createHttpTerminator({
         server,
       });
+    } else if (buildCache) {
+      // If we are not starting the server, we still want to transpile and load modules
+      await transpiler.watch();
+      await transpiler.stopWatching();
     }
 
     const replServer = shouldStartRepl && startRepl(contextRegistry, config);

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -1,6 +1,7 @@
 export interface Config {
   alwaysFakeOptionals: boolean;
   basePath: string;
+  buildCache: boolean;
   generate: {
     routes: boolean;
     types: boolean;


### PR DESCRIPTION
Adds a new `buildCache` option (`-b ` or `--build-cache`) that will rebuild the local cache (implicitly generating the routes and types) without starting the server.

Fixes: https://github.com/pmcelhaney/counterfact/issues/1304