### PR TITLE
Fix an error with $.proxy() and GET requests

### DIFF
--- a/.changeset/forty-paths-tease.md
+++ b/.changeset/forty-paths-tease.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+fix error with $.proxy() when making a GET request

--- a/src/server/dispatcher.ts
+++ b/src/server/dispatcher.ts
@@ -241,6 +241,8 @@ export class Dispatcher {
     req,
   }: DispatcherRequest): Promise<CounterfactResponseObject> {
     debug(`request: ${method} ${path}`);
+    debug(`headers: ${JSON.stringify(headers)}`);
+    debug(`body: ${JSON.stringify(body)}`);
 
     // If the incoming path includes the base path, remove it
     if (

--- a/src/server/koa-middleware.ts
+++ b/src/server/koa-middleware.ts
@@ -93,7 +93,7 @@ export function koaMiddleware(
     const response = await dispatcher.request({
       auth,
 
-      body,
+      body: method === "HEAD" || method === "GET" ? undefined : body,
 
       /* @ts-expect-error the value of a header can be an array and we don't have a solution for that yet */
       headers,

--- a/src/server/registry.ts
+++ b/src/server/registry.ts
@@ -34,6 +34,7 @@ interface RequestData {
   query: { [key: string]: number | string | boolean };
   response: ResponseBuilderFactory;
   tools: Tools;
+  body?: unknown;
 }
 
 interface RequestDataWithBody extends RequestData {

--- a/test/server/dispatcher.proxy.test.ts
+++ b/test/server/dispatcher.proxy.test.ts
@@ -23,10 +23,6 @@ describe("a dispatcher passes a proxy function to the operation", () => {
         status: 200,
 
         async text() {
-          if (typeof url !== "string") {
-            throw new TypeError("url is not a string");
-          }
-
           return await Promise.resolve(`body from ${url}`);
         },
       });
@@ -41,7 +37,6 @@ describe("a dispatcher passes a proxy function to the operation", () => {
       },
     });
 
-    // @ts-expect-error I don't understand why TS says contentType and headers don't exist
     const { body, contentType, headers, status } = response;
 
     expect(body).toBe("body from https://example.com/a?x=1");

--- a/test/server/koa-middleware.test.ts
+++ b/test/server/koa-middleware.test.ts
@@ -336,6 +336,46 @@ describe("koa middleware", () => {
     expect(ctx.body).toBe("Hello, Homer!");
   });
 
+  it("does not pass a request body for a GET request", async () => {
+    const registry = new Registry();
+
+    registry.add("/hello", {
+      GET(requestData) {
+        return {
+          body: `Hello, ${requestData?.body?.name}!`,
+        };
+      },
+    });
+
+    const dispatcher = new Dispatcher(registry, new ContextRegistry());
+    const middleware = koaMiddleware(dispatcher, {
+      ...CONFIG,
+      routePrefix: "/api/v1",
+    });
+
+    const ctx = {
+      req: {
+        path: "/api/v1/hello",
+      },
+
+      request: {
+        body: { name: "Homer" },
+        headers: {},
+        method: "GET",
+        path: "/api/v1/hello",
+      },
+
+      set: jest.fn(),
+    } as unknown as ParameterizedContext;
+
+    await middleware(ctx, async () => {
+      await Promise.resolve(undefined);
+    });
+
+    expect(ctx.status).toBe(200);
+    expect(ctx.body).toBe("Hello, undefined!");
+  });
+
   it("collects basic authorization headers", async () => {
     const registry = new Registry();
 


### PR DESCRIPTION
It appears that Koa is adding an empty request body to GET requests. Get rid of it as it causes errors down the line. 