### PR TITLE
fix: temporarily make Coveralls optional during outage

### DIFF
--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -25,3 +25,4 @@ jobs:
         uses: coverallsapp/github-action@v2.3.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          fail-on-error: false


### PR DESCRIPTION
During the Coveralls outage we're making this optional