### PR TITLE
SchemaTypeCoder and ResponseTypeCoder include version number in the path when provided

### DIFF
--- a/src/typescript-generator/response-type-coder.ts
+++ b/src/typescript-generator/response-type-coder.ts
@@ -3,6 +3,7 @@ import { SchemaTypeCoder } from "./schema-type-coder.js";
 import { TypeCoder } from "./type-coder.js";
 import type { Requirement } from "./requirement.js";
 import type { Script } from "./script.js";
+import { pathJoin } from "../util/forward-slash-path.js";
 
 export class ResponseTypeCoder extends TypeCoder {
   public openApi2MediaTypes: string[];
@@ -117,7 +118,11 @@ export class ResponseTypeCoder extends TypeCoder {
   }
 
   public override modulePath(): string {
-    return `types/${this.requirement.data["$ref"] as string}.ts`;
+    return pathJoin(
+      "types",
+      this.version,
+      this.requirement.data["$ref"]! + ".ts",
+    );
   }
 
   public override writeCode(script: Script): string {

--- a/src/typescript-generator/schema-type-coder.ts
+++ b/src/typescript-generator/schema-type-coder.ts
@@ -2,6 +2,7 @@ import { buildJsDoc } from "./jsdoc.js";
 import { TypeCoder } from "./type-coder.js";
 import type { Requirement } from "./requirement.js";
 import type { Script } from "./script.js";
+import { pathJoin } from "../util/forward-slash-path.js";
 
 export class SchemaTypeCoder extends TypeCoder {
   public override names(): Generator<string> {
@@ -163,7 +164,11 @@ export class SchemaTypeCoder extends TypeCoder {
   }
 
   public override modulePath(): string {
-    return `types/${(this.requirement.data["$ref"] as string).replace(/^#\//u, "")}.ts`;
+    return pathJoin(
+      "types",
+      this.version,
+      (this.requirement.data["$ref"] as string).replace(/^#\//u, "") + ".ts",
+    );
   }
 
   public override writeCode(script: Script): string {

--- a/test/typescript-generator/response-type-coder.test.ts
+++ b/test/typescript-generator/response-type-coder.test.ts
@@ -118,6 +118,34 @@ describe("a ResponsesTypeCoder", () => {
     });
   });
 
+  describe("modulePath", () => {
+    it("returns path with types prefix and .ts extension", () => {
+      const coder = new ResponseTypeCoder(
+        new Requirement({ $ref: "responses/MyResponse" }),
+      );
+
+      expect(coder.modulePath()).toBe("types/responses/MyResponse.ts");
+    });
+
+    it("includes the version in the path when version is set", () => {
+      const coder = new ResponseTypeCoder(
+        new Requirement({ $ref: "responses/MyResponse" }),
+        "v2",
+      );
+
+      expect(coder.modulePath()).toBe("types/v2/responses/MyResponse.ts");
+    });
+
+    it("omits the version segment from the path when version is empty", () => {
+      const coder = new ResponseTypeCoder(
+        new Requirement({ $ref: "responses/MyResponse" }),
+        "",
+      );
+
+      expect(coder.modulePath()).toBe("types/responses/MyResponse.ts");
+    });
+  });
+
   describe("writeCode", () => {
     it("includes an 'examples' field in the output", () => {
       const response = new Requirement({

--- a/test/typescript-generator/schema-type-coder.test.ts
+++ b/test/typescript-generator/schema-type-coder.test.ts
@@ -367,6 +367,28 @@ describe("a SchemaTypeCoder", () => {
     expect(coder.modulePath()).toBe("types/components/Example.ts");
   });
 
+  it("includes the version in modulePath when version is set", () => {
+    const coder = new SchemaTypeCoder(
+      new Requirement({
+        $ref: "components/Example",
+      }),
+      "v2",
+    );
+
+    expect(coder.modulePath()).toBe("types/v2/components/Example.ts");
+  });
+
+  it("omits the version segment from modulePath when version is empty", () => {
+    const coder = new SchemaTypeCoder(
+      new Requirement({
+        $ref: "components/Example",
+      }),
+      "",
+    );
+
+    expect(coder.modulePath()).toBe("types/components/Example.ts");
+  });
+
   it("does not mark a property as required when it has a nested required array for its own sub-properties", async () => {
     const coder = new SchemaTypeCoder(
       new Requirement({


### PR DESCRIPTION
This is a baby step toward supporting multiple versions