### PR TITLE
Add first-class shared store across API groups

### DIFF
--- a/.changeset/bright-stores-share.md
+++ b/.changeset/bright-stores-share.md
@@ -1,0 +1,7 @@
+---
+"counterfact": minor
+---
+
+Add an optional shared store at `<basePath>/_.store.ts`, with typed access from
+route contexts, identity-preserving hot reload, and exposure through the REPL
+and programmatic simulator API.

--- a/docs/adr/xxx-first-class-store.md
+++ b/docs/adr/xxx-first-class-store.md
@@ -1,0 +1,112 @@
+# ADR xxx: First-Class Shared Store
+
+## Status
+
+Proposed
+
+## Context
+
+Counterfact now hosts multiple OpenAPI groups in one server, but a group is a
+state boundary. Each group receives its own `ContextRegistry`; only versioned
+specifications in the same group share one. That protects unrelated APIs, but
+it leaves a simulator that models a coherent multi-service product with no
+supported place to keep shared domain state.
+
+Context authors can use the existing `$.loadContext(path)` constructor helper
+inside an API group, yet they cannot safely use it to cross group boundaries.
+Sharing a root route context by convention would conflate URL-scoped state with
+product-domain state, create generated-code ownership ambiguity, and make an
+incidental folder layout part of the simulator’s domain model.
+
+The detailed contract is in [the shared-store specification](../specifications/shared-store.md).
+
+## Decision
+
+Introduce an opt-in, application-level shared store. A simulator opts in by
+providing a user-authored `<basePath>/_.store.ts`, and Counterfact constructs one
+typed live instance for each simulator returned by `counterfact()`. Context
+constructors in all groups access that instance as `$.store`; route handlers
+continue to access domain behavior through their nearest `$.context`. The same
+store is also available directly in the REPL and programmatic API.
+
+The store is constructed before route contexts, remains stable across hot reload
+and stop/start cycles of the same simulator, and is not shared with another
+simulator in the same process. It owns cross-resource domain data, invariants,
+and initial domain state. Route contexts remain responsible for path- or
+API-local behavior.
+
+The conventional path is watched even when absent. Adding `_.store.ts` to a
+running watched simulator activates the store, reloads contexts with the new
+constructor argument, and regenerates context types. Removing or breaking a
+previously loaded module retains the last good live store for that simulator;
+a new simulator without the file starts with the feature disabled.
+
+## Options
+
+### Option A: Share one root route context across all groups
+
+Make every group use a common root `routes/_.context.ts`.
+
+- **Pro:** Small runtime change and familiar existing API.
+- **Con:** Couples the shared domain model to generated route layout, causes
+  ownership/type collisions, and prevents a group from having an independent
+  root context.
+
+### Option B: Let handlers reach other groups’ contexts directly
+
+Extend `$.loadContext()` with group-qualified paths.
+
+- **Pro:** Reuses an existing mechanism and preserves each group’s local
+  context class.
+- **Con:** Makes route handlers depend on another group’s implementation and
+  URL/path layout; shared invariants become scattered across handlers.
+
+### Option C: First-class shared store (chosen)
+
+Add a conventionally located, server-level store exposed to context constructors
+as `$.store` and directly through the REPL and programmatic API.
+
+- **Pro:** Expresses a product-domain boundary directly; gives all groups a
+  typed, stable collaboration point; preserves group isolation by default.
+- **Con:** Adds lifecycle, generator, REPL, and reload responsibilities that
+  must be tested together.
+
+### Option D: External persistence only
+
+Require simulators to share a database, file, or service outside Counterfact.
+
+- **Pro:** Supports cross-process state and avoids new runtime primitives.
+- **Con:** Adds operational setup, slows the development loop, and abandons
+  Counterfact’s resettable in-memory-state model for a common simulator need.
+
+## Consequences
+
+- Multi-service simulators can model coherent entities and enforce references
+  across API groups.
+- Existing simulators stay backward compatible and group-isolated unless they
+  add `<basePath>/_.store.ts`.
+- The runtime needs a dedicated store loader that preserves the live instance,
+  updates its prototype on successful reload, and adds new fields without
+  overwriting existing domain data.
+- The store watcher must observe the conventional path even before it exists,
+  coordinate context reloads when a store is first added, and trigger context
+  type regeneration when type watching is enabled.
+- When `<basePath>/_.store.ts` exists, the generator must add a typed `$.store`
+  to every group's context constructor types without changing operation,
+  middleware, or scenario types.
+- Integration tests must exercise cross-group behavior through real HTTP, and
+  unit tests must cover the store lifecycle independently.
+
+## Advice
+
+- Put business rules that refer to more than one API group in the store. Expose
+  those rules to handlers through their route contexts, and keep request parsing
+  and operation-specific response mapping in route handlers.
+- Do not introduce external persistence as part of this feature. A newly
+  constructed simulator remains a clean state even when another simulator
+  exists in the same process.
+- Do not use a store as a shortcut for unrelated API groups to share arbitrary
+  implementation details; its API should describe the simulated product domain.
+- Preserve the current path-scoped context API without qualification. Add
+  cross-group access only through the store surface unless a later, separate
+  ADR establishes another use case.

--- a/docs/adr/xxx-first-class-store.md
+++ b/docs/adr/xxx-first-class-store.md
@@ -109,4 +109,4 @@ Require simulators to share a database, file, or service outside Counterfact.
   implementation details; its API should describe the simulated product domain.
 - Preserve the current path-scoped context API without qualification. Add
   cross-group access only through the store surface unless a later, separate
-  ADR establishes another use case.
+  ADR establishes another use case. (Patrick McElhaney)

--- a/docs/features/hot-reload.md
+++ b/docs/features/hot-reload.md
@@ -12,8 +12,16 @@ Find the file corresponding to the route, change behavior by editing the TypeScr
 
 Depending on the scenario, you may want to commit your changes to source control or throw them away.
 
+When `<basePath>/_.store.ts` exists, it is hot-reloaded separately from route
+contexts. Counterfact preserves the live store object's identity and existing
+fields, updates prototype methods, and adds newly declared enumerable fields.
+An invalid edit or deletion keeps the last successfully loaded store active and
+prints a diagnostic. See [Share State Across API Groups](../patterns/shared-store.md)
+for the supported store-authoring model.
+
 ## See also
 
 - [State](./state.md) — in-memory state that survives reloads
+- [Patterns: Share State Across API Groups](../patterns/shared-store.md) — store-specific reload behavior across API groups
 - [REPL](./repl.md) — make changes without touching files at all
 - [Usage](../usage.md)

--- a/docs/features/programmatic-api.md
+++ b/docs/features/programmatic-api.md
@@ -32,6 +32,31 @@ const rootContext = contextRegistry.find("/");
 
 Once you have `rootContext` you can read and write any state that your route handlers expose.
 
+## Accessing an application-level store
+
+If `<basePath>/_.store.ts` exists, `counterfact()` constructs one shared store
+for the simulator and exposes it through the optional `store` property. Supply
+the user-authored store type as the generic argument when you want typed access:
+
+```ts
+import { counterfact } from "counterfact";
+import type { Store } from "./api/_.store.js";
+
+const simulator = await counterfact<Store>(config, specs);
+
+if (simulator.store === undefined) {
+  throw new Error("Expected api/_.store.ts to be loaded");
+}
+
+simulator.store.seed();
+const { stop } = await simulator.start(config);
+```
+
+The property remains optional because the published API cannot infer whether a
+caller-local file exists. The object is the same live store used by every API
+group's context constructors and by the REPL. It is available before `start()`
+when discovered during simulator construction.
+
 ## Example: parameterised auth scenario with Playwright
 
 Given this route handler:
@@ -170,12 +195,14 @@ const { start } = await counterfact(config, [
 | `contextRegistry` | `ContextRegistry`              | Registry of all context objects keyed by path. Call `.find(path)` to get the context for a given route prefix.               |
 | `registry`        | `Registry`                     | Registry of all loaded route modules.                                                                                        |
 | `koaApp`          | `Koa`                          | The underlying Koa application.                                                                                              |
+| `store`           | `TStore \| undefined`          | Optional application-level store loaded from `<basePath>/_.store.ts`. Supply `TStore` to `counterfact<TStore>()`.            |
 | `start(config)`   | `async (config) => { stop() }` | Starts the server (and optionally the file watcher and code generator). Returns a `stop()` function to gracefully shut down. |
 | `startRepl()`     | `() => REPLServer`             | Starts the interactive REPL. Returns the REPL server instance.                                                               |
 
 ## See also
 
 - [State](./state.md) — the context objects you manipulate from test code
+- [Patterns: Share State Across API Groups](../patterns/shared-store.md) — typed shared state for multi-API simulations
 - [Patterns: Automated Integration Tests](../patterns/automated-integration-tests.md) — using the programmatic API in a CI-friendly test suite
 - [Reference](../reference.md) — CLI flags, architecture
 - [Usage](../usage.md)

--- a/docs/features/repl.md
+++ b/docs/features/repl.md
@@ -36,20 +36,34 @@ const petsContext = loadContext("/pets");
 When running multiple APIs in one process, REPL state is grouped by API key:
 
 ```js
-context.billing
-context.inventory
-routes.billing
-routes.inventory
+context.billing;
+context.inventory;
+routes.billing;
+routes.inventory;
 ```
 
 In this mode, `loadContext` and `route` are also grouped by API key:
 
 ```js
-loadContext.billing("/pets")
-route.inventory("/stock/{sku}")
+loadContext.billing("/pets");
+route.inventory("/stock/{sku}");
 ```
 
 When configuring multiple APIs, each API must define a non-empty, unique group name.
+
+If `<basePath>/_.store.ts` exists, `store` is an unqualified REPL binding in
+both single- and multi-API sessions. It is the same live application-level
+object received by every group's context constructors:
+
+```js
+store.customers.size;
+store.orders.clear();
+```
+
+Adding a valid `_.store.ts` while the server is watching makes the binding
+available to an already-open REPL. Scenario functions do not receive the store
+in their `$` argument; use a context method when a scenario needs to seed shared
+state.
 
 The built-in `client` object lets you make HTTP requests from the prompt without leaving the terminal:
 
@@ -67,11 +81,11 @@ The built-in `route()` function creates a fluent request builder that validates 
 
 ```js
 // Build and inspect before sending
-const req = route("/pet/{petId}").method("get").path({ petId: 42 })
-req.ready()    // true / false
-req.missing()  // lists missing required parameters
-req.help()     // prints OpenAPI docs for the operation
-await req.send()
+const req = route("/pet/{petId}").method("get").path({ petId: 42 });
+req.ready(); // true / false
+req.missing(); // lists missing required parameters
+req.help(); // prints OpenAPI docs for the operation
+await req.send();
 ```
 
 See the [Route Builder guide](./route-builder.md) for full documentation.
@@ -94,11 +108,11 @@ Tab completion supports both modes: in single-API sessions, `.scenario <Tab>` su
 
 **Path resolution:** the argument to `.scenario` is a slash-separated path. The last segment is the function name; everything before it is the file path, resolved relative to `<basePath>/scenarios/` (with `index.ts` as the default file).
 
-| Command | File | Function |
-|---|---|---|
-| `.scenario soldPets` | `scenarios/index.ts` | `soldPets` |
-| `.scenario pets/resetAll` | `scenarios/pets.ts` | `resetAll` |
-| `.scenario pets/orders/pending` | `scenarios/pets/orders.ts` | `pending` |
+| Command                         | File                       | Function   |
+| ------------------------------- | -------------------------- | ---------- |
+| `.scenario soldPets`            | `scenarios/index.ts`       | `soldPets` |
+| `.scenario pets/resetAll`       | `scenarios/pets.ts`        | `resetAll` |
+| `.scenario pets/orders/pending` | `scenarios/pets/orders.ts` | `pending`  |
 
 A scenario function receives a single argument with `{ context, loadContext, routes, route }`:
 
@@ -113,11 +127,10 @@ export const soldPets: Scenario = ($) => {
   $.context.petService.addPet({ id: 2, status: "available" });
 
   // Store a pre-configured route builder for later use in the REPL
-  $.routes.findSold = $
-    .route("/pet/findByStatus")
+  $.routes.findSold = $.route("/pet/findByStatus")
     .method("get")
     .query({ status: "sold" });
-}
+};
 ```
 
 After the command runs you can immediately use anything stored in `$.routes`:
@@ -162,7 +175,11 @@ import type { Scenario$ } from "../types/_.context.js";
 
 export function addPets($: Scenario$, count: number, species: string) {
   for (let i = 0; i < count; i++) {
-    $.context.addPet({ name: `${species} ${i + 1}`, status: "available", photoUrls: [] });
+    $.context.addPet({
+      name: `${species} ${i + 1}`,
+      status: "available",
+      photoUrls: [],
+    });
   }
 }
 ```
@@ -175,4 +192,5 @@ If `startup` is not exported from `scenarios/index.ts`, it is silently skipped â
 - [State](./state.md) â€” the context objects you interact with from the REPL
 - [Patterns: Scenario Scripts](../patterns/scenario-scripts.md)
 - [Patterns: Live Server Inspection with the REPL](../patterns/repl-inspection.md)
+- [Patterns: Share State Across API Groups](../patterns/shared-store.md)
 - [Usage](../usage.md)

--- a/docs/features/state.md
+++ b/docs/features/state.md
@@ -74,10 +74,51 @@ export class Context {
 }
 ```
 
+## Sharing state across API groups
+
+Context registries are isolated between API groups. When several groups model
+one product and need shared domain data, add a user-authored `_.store.ts` at the
+root of `basePath`:
+
+```ts
+// _.store.ts
+export class Store {
+  readonly customers = new Map<string, Customer>();
+  readonly orders = new Map<string, Order>();
+}
+```
+
+Counterfact constructs one store per simulator and passes it to every context
+constructor as `$.store`. Import the generated `Context$` type for concrete,
+typed access:
+
+```ts
+// customers/routes/_.context.ts
+import type { Context$ } from "../types/_.context.js";
+
+export class Context {
+  readonly store: Context$["store"];
+
+  constructor($: Context$) {
+    this.store = $.store;
+  }
+}
+```
+
+The store is not added to route-handler, middleware, or scenario arguments.
+Handlers continue to use `$.context`; each context decides which store behavior
+to expose to its routes.
+
+The live store survives route, context, and store-module hot reloads as well as
+a stop/start cycle on the same simulator. Constructing a new simulator creates a
+fresh store. See [Share State Across API Groups](../patterns/shared-store.md) for
+a complete multi-group example and reload guidance.
+
 ## See also
 
 - [Hot reload](./hot-reload.md) — state is preserved across hot reloads
 - [REPL](./repl.md) — inspect and mutate state interactively at runtime
 - [Patterns: Federated Context Files](../patterns/federated-context.md) — managing state across multiple context files
+- [Patterns: Share State Across API Groups](../patterns/shared-store.md) — sharing domain state between independently generated groups
 - [Patterns: Test the Context, Not the Handlers](../patterns/test-context-not-handlers.md) — unit-testing context logic
 - [Usage](../usage.md)

--- a/docs/patterns/automated-integration-tests.md
+++ b/docs/patterns/automated-integration-tests.md
@@ -148,6 +148,7 @@ it("returns 404 when the flag is set", async () => {
 
 ## Keep exploring
 
+- [Share State Across API Groups](./shared-store.md) — exercise product-wide workflows backed by one shared store
 - [Simulate Failures and Edge Cases](./simulate-failures.md) — the context-flag technique for toggling error conditions
 - [Test the Context, Not the Handlers](./test-context-not-handlers.md) — unit-test context logic independently of the HTTP layer
 - [Mock APIs with Dummy Data](./mock-with-dummy-data.md) — shape the responses the integration tests assert against

--- a/docs/patterns/federated-context.md
+++ b/docs/patterns/federated-context.md
@@ -86,6 +86,7 @@ The `loadContext(path)` call returns the live context instance rooted at that pa
 
 ## Keep exploring
 
+- [Share State Across API Groups](./shared-store.md) — use an application-level store when collaborating routes belong to different API groups
 - [Test the Context, Not the Handlers](./test-context-not-handlers.md) — unit-test each context class independently
 - [Mock APIs with Dummy Data](./mock-with-dummy-data.md) — the pattern that introduces the single-context approach this one extends
 - [Live Server Inspection with the REPL](./repl-inspection.md) — inspect each domain's context live from the REPL

--- a/docs/patterns/index.md
+++ b/docs/patterns/index.md
@@ -4,30 +4,31 @@ These playbooks show how people use Counterfact in real development and test wor
 
 Most projects start with [Explore a New API](./explore-new-api.md) or [Executable Spec](./executable-spec.md) to get a running server from an OpenAPI spec with no code. From there, [Mock APIs with Dummy Data](./mock-with-dummy-data.md) and [AI-Assisted Implementation](./ai-assisted-implementation.md) are the natural next steps for adding realistic responses — the former by hand, the latter with an AI agent doing the heavy lifting.
 
-As the mock grows, [Scenario Scripts](./scenario-scripts.md) let you automate repetitive REPL interactions — seeding data on startup, building reusable request sequences — while [Federated Context Files](./federated-context.md) and [Test the Context, Not the Handlers](./test-context-not-handlers.md) keep the stateful logic organized and reliable. [Live Server Inspection with the REPL](./repl-inspection.md) is Counterfact's most distinctive feature, letting you seed data, send requests, and toggle behavior in real time without restarting, and [Simulate Failures and Edge Cases](./simulate-failures.md) and [Simulate Realistic Latency](./simulate-latency.md) extend any mock to cover the error paths and performance characteristics that real services exhibit.
+As the mock grows, [Scenario Scripts](./scenario-scripts.md) let you automate repetitive REPL interactions — seeding data on startup, building reusable request sequences — while [Federated Context Files](./federated-context.md), [Share State Across API Groups](./shared-store.md), and [Test the Context, Not the Handlers](./test-context-not-handlers.md) keep stateful logic organized and reliable. [Live Server Inspection with the REPL](./repl-inspection.md) is Counterfact's most distinctive feature, letting you seed data, send requests, and toggle behavior in real time without restarting, and [Simulate Failures and Edge Cases](./simulate-failures.md) and [Simulate Realistic Latency](./simulate-latency.md) extend any mock to cover the error paths and performance characteristics that real services exhibit.
 
 When your project involves multiple versions or multiple specs, [Multiple API Versions](./multiple-versions.md) shows how to serve them from a shared set of route files using `$.minVersion()` to branch on version without duplicating handlers. For teams that want the mock to remain a reliable, long-lived artifact, [Reference Implementation](./reference-implementation.md) and [Automated Integration Tests](./automated-integration-tests.md) make it a first-class part of the codebase that can run in CI. Finally, [Agentic Sandbox](./agentic-sandbox.md) and [Hybrid Proxy](./hybrid-proxy.md) address the two common integration strategies — isolating an AI agent from the real service, or blending mock and live traffic — and [Custom Middleware](./custom-middleware.md) covers cross-cutting concerns like authentication and logging without touching individual handlers.
 
 ## Find your path
 
-| Pattern | When to use it |
-|---|---|
-| [Explore a New API](./explore-new-api.md) | You have a spec but no running backend or production access |
-| [Executable Spec](./executable-spec.md) | You want immediate feedback on how spec changes affect the running server during API design |
-| [Mock APIs with Dummy Data](./mock-with-dummy-data.md) | You need realistic-looking responses to build a UI, run a demo, or write assertions |
-| [Scenario Scripts](./scenario-scripts.md) | You want to automate REPL interactions, seed data on startup, or build reusable state configurations |
-| [AI-Assisted Implementation](./ai-assisted-implementation.md) | You want an AI agent to replace random responses with working handler logic |
-| [Federated Context Files](./federated-context.md) | You want each domain to own its state, with explicit cross-domain dependencies |
-| [Test the Context, Not the Handlers](./test-context-not-handlers.md) | You want to keep shared stateful logic reliable as the mock grows |
-| [Live Server Inspection with the REPL](./repl-inspection.md) | You want to seed data, send requests, and toggle behavior without restarting the server |
-| [Simulate Failures and Edge Cases](./simulate-failures.md) | You need reproducible, on-demand error conditions for development or testing |
-| [Simulate Realistic Latency](./simulate-latency.md) | You want to test how clients and UIs behave under realistic response times |
-| [Reference Implementation](./reference-implementation.md) | You want a working, executable implementation that expresses intended API behavior in code |
-| [Multiple API Versions](./multiple-versions.md) | You maintain multiple versions of an API and want shared handlers that adapt by version |
-| [Agentic Sandbox](./agentic-sandbox.md) | You are building an AI coding agent and want to avoid rate limits and costs during development |
-| [Hybrid Proxy](./hybrid-proxy.md) | Some endpoints exist in the real backend; others need to be mocked |
-| [Automated Integration Tests](./automated-integration-tests.md) | You want to run real HTTP tests against the mock in a CI-friendly test suite |
-| [Custom Middleware](./custom-middleware.md) | You want authentication, headers, or logging applied uniformly across a group of routes |
+| Pattern                                                              | When to use it                                                                                       |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Explore a New API](./explore-new-api.md)                            | You have a spec but no running backend or production access                                          |
+| [Executable Spec](./executable-spec.md)                              | You want immediate feedback on how spec changes affect the running server during API design          |
+| [Mock APIs with Dummy Data](./mock-with-dummy-data.md)               | You need realistic-looking responses to build a UI, run a demo, or write assertions                  |
+| [Scenario Scripts](./scenario-scripts.md)                            | You want to automate REPL interactions, seed data on startup, or build reusable state configurations |
+| [AI-Assisted Implementation](./ai-assisted-implementation.md)        | You want an AI agent to replace random responses with working handler logic                          |
+| [Federated Context Files](./federated-context.md)                    | You want each domain to own its state, with explicit cross-domain dependencies                       |
+| [Share State Across API Groups](./shared-store.md)                   | Several API groups model one product and need shared domain data or invariants                       |
+| [Test the Context, Not the Handlers](./test-context-not-handlers.md) | You want to keep shared stateful logic reliable as the mock grows                                    |
+| [Live Server Inspection with the REPL](./repl-inspection.md)         | You want to seed data, send requests, and toggle behavior without restarting the server              |
+| [Simulate Failures and Edge Cases](./simulate-failures.md)           | You need reproducible, on-demand error conditions for development or testing                         |
+| [Simulate Realistic Latency](./simulate-latency.md)                  | You want to test how clients and UIs behave under realistic response times                           |
+| [Reference Implementation](./reference-implementation.md)            | You want a working, executable implementation that expresses intended API behavior in code           |
+| [Multiple API Versions](./multiple-versions.md)                      | You maintain multiple versions of an API and want shared handlers that adapt by version              |
+| [Agentic Sandbox](./agentic-sandbox.md)                              | You are building an AI coding agent and want to avoid rate limits and costs during development       |
+| [Hybrid Proxy](./hybrid-proxy.md)                                    | Some endpoints exist in the real backend; others need to be mocked                                   |
+| [Automated Integration Tests](./automated-integration-tests.md)      | You want to run real HTTP tests against the mock in a CI-friendly test suite                         |
+| [Custom Middleware](./custom-middleware.md)                          | You want authentication, headers, or logging applied uniformly across a group of routes              |
 
 ## See also
 

--- a/docs/patterns/repl-inspection.md
+++ b/docs/patterns/repl-inspection.md
@@ -81,6 +81,7 @@ If the context exposes a failure flag (see [Simulate Failures and Edge Cases](./
 
 ## Keep exploring
 
+- [Share State Across API Groups](./shared-store.md) — inspect the unqualified live `store` shared by every API group
 - [Simulate Failures and Edge Cases](./simulate-failures.md) — expose context flags that the REPL can toggle
 - [Federated Context Files](./federated-context.md) — use `$.loadContext()` in the REPL to inspect a specific domain's context
 - [Mock APIs with Dummy Data](./mock-with-dummy-data.md) — use the REPL to seed and inspect stateful handler data

--- a/docs/patterns/shared-store.md
+++ b/docs/patterns/shared-store.md
@@ -1,0 +1,181 @@
+# Share State Across API Groups
+
+Model one product across several OpenAPI groups without coupling one group's
+routes to another group's context tree.
+
+## Why teams use this
+
+Counterfact normally gives each API group its own context registry. That is the
+right default for unrelated APIs, but a multi-service simulator often needs to
+enforce product-wide rules: an order must reference an existing customer, an
+invoice must reference an order, or several services must agree on account
+status.
+
+Reaching into another group's context would make domain logic depend on that
+group's route layout. A shared store gives the simulator one application-level
+home for cross-group data and invariants while each group keeps its own local
+contexts.
+
+## How it works
+
+Add one user-authored `_.store.ts` at the root of `basePath`:
+
+```text
+api/
+  _.store.ts
+  customers/
+    routes/
+      _.context.ts
+      customers.ts
+  orders/
+    routes/
+      _.context.ts
+      orders.ts
+```
+
+The module must export a zero-argument `Store` class. Counterfact constructs one
+store for each simulator instance and passes it only to context constructors as
+`$.store`. Route handlers continue to use their nearest `$.context`.
+
+## Example
+
+Put shared entities and cross-group rules in the store:
+
+```ts
+// api/_.store.ts
+interface Customer {
+  id: string;
+  name: string;
+}
+
+interface Order {
+  id: string;
+  customerId: string;
+}
+
+export class Store {
+  readonly customers = new Map<string, Customer>();
+  readonly orders = new Map<string, Order>();
+
+  createOrder(order: Order): Order {
+    if (!this.customers.has(order.customerId)) {
+      throw new Error(`Unknown customer: ${order.customerId}`);
+    }
+
+    this.orders.set(order.id, structuredClone(order));
+    return structuredClone(order);
+  }
+}
+```
+
+Each group wraps the shared store with its own route-facing context API. The
+generated `Context$` type imports the concrete `Store` type from `_.store.ts`:
+
+```ts
+// api/customers/routes/_.context.ts
+import type { Context$ } from "../types/_.context.js";
+
+export class Context {
+  private readonly store: Context$["store"];
+
+  constructor($: Context$) {
+    this.store = $.store;
+  }
+
+  addCustomer(customer: { id: string; name: string }) {
+    this.store.customers.set(customer.id, structuredClone(customer));
+    return structuredClone(customer);
+  }
+}
+```
+
+```ts
+// api/orders/routes/_.context.ts
+import type { Context$ } from "../types/_.context.js";
+
+export class Context {
+  private readonly store: Context$["store"];
+
+  constructor($: Context$) {
+    this.store = $.store;
+  }
+
+  createOrder(order: { id: string; customerId: string }) {
+    return this.store.createOrder(order);
+  }
+}
+```
+
+Handlers stay small and do not receive the store directly:
+
+```ts
+// api/orders/routes/orders.ts
+export const POST: HTTP_POST = ($) =>
+  $.response[201].json($.context.createOrder($.body));
+```
+
+## Inspect and seed the shared state
+
+When the store exists, the REPL exposes the same live object as `store`:
+
+```js
+store.customers.size;
+store.orders.clear();
+```
+
+The programmatic API also exposes it. Supply the store type explicitly when you
+want typed access from a test or setup script:
+
+```ts
+import { counterfact } from "counterfact";
+import type { Store } from "./api/_.store.js";
+
+const simulator = await counterfact<Store>(config, specs);
+
+if (simulator.store === undefined) {
+  throw new Error("Expected api/_.store.ts");
+}
+
+simulator.store.customers.set("customer-1", {
+  id: "customer-1",
+  name: "Ada",
+});
+```
+
+Scenario arguments deliberately do not receive `store`; seed it through the
+programmatic API, the REPL, or methods exposed by a group's context.
+
+## Reload behavior
+
+The store lives for the lifetime of the simulator returned by `counterfact()`.
+A stop/start cycle preserves it, while a new simulator receives a fresh store.
+
+On a successful store-module reload, Counterfact preserves the live object's
+identity and existing fields, updates prototype methods, and adds newly declared
+enumerable fields. It never overwrites or removes existing fields automatically.
+If a later edit is invalid or the file is deleted, the running simulator keeps
+the last good store and reports the reload failure.
+
+Use prototype methods and ordinary instance fields for reloadable store code.
+ECMAScript `#private` fields are not compatible with prototype replacement.
+
+## What you get
+
+- All API groups observe the same live domain state when the simulator opts in.
+- Cross-group invariants have one explicit owner instead of being scattered
+  across route handlers.
+- Group-local contexts and `loadContext(path)` keep their existing boundaries.
+- Projects without `<basePath>/_.store.ts` retain isolated group state and their
+  existing behavior.
+
+## Keep exploring
+
+- [Federated Context Files](./federated-context.md) — keep state local when the
+  collaborating routes are in one API group
+- [Test the Context, Not the Handlers](./test-context-not-handlers.md) — unit-test
+  the context methods that wrap store behavior
+- [Automated Integration Tests](./automated-integration-tests.md) — verify
+  cross-group workflows through real HTTP requests
+- [Live Server Inspection with the REPL](./repl-inspection.md) — inspect and
+  mutate live simulator state interactively
+- [State](../features/state.md) — context and store lifecycle reference

--- a/docs/patterns/test-context-not-handlers.md
+++ b/docs/patterns/test-context-not-handlers.md
@@ -95,6 +95,7 @@ The context class has no dependency on Counterfact internals — no server, no `
 
 ## Keep exploring
 
+- [Share State Across API Groups](./shared-store.md) — apply the same testing boundary to context methods that wrap shared-store behavior
 - [Mock APIs with Dummy Data](./mock-with-dummy-data.md) — the context pattern the tests above are written for
 - [AI-Assisted Implementation](./ai-assisted-implementation.md) — unit-test the context the agent generates to keep it reliable
 - [Reference Implementation](./reference-implementation.md) — a reference implementation accumulates significant context logic that benefits from test coverage

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -49,6 +49,7 @@ OpenAPI spec (YAML or JSON, local or URL)
 
 ```
 <output-directory>/
+├── _.store.ts                 # application-level state shared across API groups (optional)
 ├── routes/
 │   ├── _.context.ts           # shared in-memory state (optional)
 │   ├── _.middleware.ts        # custom Koa middleware (optional)
@@ -182,6 +183,53 @@ export class Context {
 }
 ```
 
+### Application-level shared store
+
+For a simulator with multiple API groups, place one user-authored
+`<basePath>/_.store.ts` alongside the group directories. The module must export
+a zero-argument `Store` class. Counterfact constructs one instance for the
+simulator and passes it to every route context constructor:
+
+```ts
+// <basePath>/_.store.ts
+export class Store {
+  readonly customers = new Map<string, Customer>();
+  readonly orders = new Map<string, Order>();
+}
+```
+
+```ts
+// <basePath>/orders/routes/_.context.ts
+import type { Context$ } from "../types/_.context.js";
+
+export class Context {
+  private readonly store: Context$["store"];
+
+  constructor($: Context$) {
+    this.store = $.store;
+  }
+
+  createOrder(order: Order) {
+    if (!this.store.customers.has(order.customerId)) {
+      throw new Error(`Unknown customer: ${order.customerId}`);
+    }
+    this.store.orders.set(order.id, order);
+    return order;
+  }
+}
+```
+
+Only the generated context-constructor type receives `store`; operation,
+middleware, and scenario `$` arguments do not. `counterfact<TStore>()` exposes
+the same object as optional `simulator.store`, and the REPL exposes it as
+`store`.
+
+The store is discovered only at `<basePath>/_.store.ts`. Its identity and
+existing fields survive successful hot reloads and stop/start cycles of the
+same simulator. A new simulator creates a fresh instance. See the
+[Share State Across API Groups](./patterns/shared-store.md) pattern for a full
+workflow.
+
 ### Cross-context communication with `loadContext()`
 
 Route handlers can reach into a _different_ subtree's context using the `loadContext(path)` function injected into every handler. This lets sibling or parent routes share data without merging everything into one big context.
@@ -208,6 +256,11 @@ Counterfact watches the routes directory with [chokidar](https://github.com/paul
 1. The module is re-imported.
 2. The handler is swapped in the registry.
 3. The `Context` instance **is preserved** — in-memory data survives the reload.
+
+The application-level store follows the same identity-preserving principle.
+Store reloads update prototype methods and add new enumerable fields without
+overwriting existing state. A broken or deleted store source leaves the last
+good live object in place.
 
 No restart required.
 

--- a/docs/specifications/shared-store.md
+++ b/docs/specifications/shared-store.md
@@ -1,0 +1,235 @@
+# Shared Store Specification
+
+## Status
+
+Proposed.
+
+## Purpose
+
+Counterfact SHALL support one optional, application-level **store** that is
+shared by every API group in a server instance. It gives a simulator a single
+home for domain data and rules that span independently generated OpenAPI groups,
+while preserving the existing path-scoped `$.context` abstraction.
+
+The store is in-memory and survives route and context-module hot reloads for the
+life of one simulator instance returned by `counterfact()`. It does not persist
+across construction of a new simulator instance or a process restart. Two
+simulators created in the same process receive different store instances.
+
+## Non-goals
+
+- Persisting simulator state to disk or an external database.
+- Replacing per-route and per-subtree `$.context` instances.
+- Automatically inferring relationships from OpenAPI documents.
+- Providing distributed transactions, locking, or multi-process sharing.
+- Making API groups share state unless the simulator opts in.
+- Supporting several stores in the initial release.
+- Automatically migrating or replacing existing store fields when their
+  initializers change.
+
+## Layout and discovery
+
+An opt-in simulator places one user-authored store module at the root of
+`config.basePath`:
+
+```text
+<basePath>/
+  _.store.ts
+  customers/
+  orders/
+```
+
+The presence of `<basePath>/_.store.ts` opts the simulator into the shared
+store; no configuration key is required. The file MUST export a constructable
+`Store` class. `counterfact()` loads the module and constructs exactly one
+instance before loading route contexts, so the instance is available to every
+context constructor and on the object returned by `counterfact()`. Calling
+`start()`, `stop()`, and then `start()` again on the same simulator does not
+reconstruct or reset the store. Constructing a new simulator constructs a fresh
+store.
+
+Discovery is not limited to initial startup. When server watching starts,
+Counterfact MUST watch the exact `<basePath>/_.store.ts` path even when the file
+does not yet exist. Creating a valid store module activates the feature for the
+running simulator: Counterfact constructs the store, exposes it through the
+simulator object and REPL, and reloads every route context module so its
+constructor receives `$.store` while existing context state remains subject to
+the normal `ContextRegistry` preservation rules.
+
+Single-spec projects and multi-spec projects without `<basePath>/_.store.ts`
+retain their current behavior and receive no new required files.
+
+## Context API
+
+For an enabled simulator, every route context constructor receives the store
+through its existing context argument:
+
+```ts
+$.store;
+```
+
+It is the live instance exported by `<basePath>/_.store.ts`, with its concrete
+type exposed to TypeScript. The existing `$.loadContext(path)` and
+`$.readJson(path)` context-constructor helpers retain their current behavior.
+`$.loadContext(path)` continues to address contexts within the context's API
+group.
+
+For example, two independently generated groups can enforce a shared
+relationship through their own route contexts without importing each other’s
+contexts:
+
+```ts
+// _.store.ts
+export class Store {
+  readonly customers = new Map<string, Customer>();
+  readonly orders = new Map<string, Order>();
+
+  createOrder(order: Order): Order {
+    if (!this.customers.has(order.customerId)) {
+      throw new Error(`Unknown customer: ${order.customerId}`);
+    }
+    this.orders.set(order.id, structuredClone(order));
+    return structuredClone(order);
+  }
+}
+
+// orders/routes/_.context.ts
+import type { Context$ } from "../types/_.context.js";
+
+export class Context {
+  private readonly store: Context$["store"];
+
+  constructor($: Context$) {
+    this.store = $.store;
+  }
+
+  createOrder(order: Order): Order {
+    return this.store.createOrder(order);
+  }
+}
+
+// orders/routes/orders.ts
+export const POST: HTTP_POST = ($) =>
+  $.response[201].json($.context.createOrder($.body));
+```
+
+Counterfact MUST generate the store type into every API group’s context
+constructor type when `<basePath>/_.store.ts` exists. Each generated context
+type imports `Store` directly from that module using a relative, `.js`-suffixed
+type-only import. Generated files MUST remain regenerated artifacts. The store
+MUST NOT be added directly to operation, middleware, or scenario arguments.
+
+Initial type generation detects whether the conventional module exists. While
+type watching is enabled, successfully creating the module MUST regenerate all
+groups' context constructor types to add `$.store`. Changes to the exported
+`Store` type flow through the generated type-only imports without copying the
+user-authored type into generated files.
+
+## REPL
+
+In a multi-API REPL, `store` exposes the same live object. This is additive to
+the existing group-keyed `context`, `loadContext`, and `routes` surfaces. In a
+single-API REPL, the new `store` binding is also available when the store module
+exists.
+Scenario arguments retain their existing shape and do not receive the store.
+
+## Reload and failure behavior
+
+- Route and normal context hot reload MUST continue to preserve their existing
+  in-memory state.
+- On a successful reload, Counterfact MUST preserve the live store object's
+  identity and replace its prototype with the newly loaded `Store.prototype`.
+  This updates prototype methods without reconstructing the live store.
+- Counterfact MUST construct a temporary candidate from the newly loaded class.
+  Each enumerable own field present on the candidate but absent from the live
+  store is copied to the live store. Existing own fields are never overwritten
+  or deleted during automatic reload, even when their initializer changed or
+  was removed from the source module. This preserves live domain data and makes
+  newly added fields available deterministically.
+- Store authors MUST use prototype methods and ordinary own fields for
+  reloadable behavior and state. ECMAScript `#private` fields, symbol-keyed
+  fields, non-enumerable instance fields, and mutable static state are outside
+  the reload contract. In particular, methods loaded from a new class cannot
+  safely access private fields branded by an older class definition.
+- If an initial store module exists but does not export a constructable `Store`,
+  or throws while loading or constructing, `counterfact()` MUST reject with an
+  error containing the absolute module path and underlying error. An absent
+  module disables the feature and is not an error.
+- If a previously successful store module later becomes invalid, throws, or is
+  deleted, Counterfact MUST keep the last successfully loaded prototype and live
+  store. It MUST print an actionable diagnostic to standard error containing
+  the absolute module path and underlying error, and continue serving requests.
+  A failed reload MUST NOT substitute a new empty store or partially apply the
+  candidate module.
+- Deleting the module does not deactivate the store in the current simulator;
+  it is handled as a failed runtime reload and the last good object remains
+  live. When type watching is enabled, however, Counterfact MUST regenerate
+  context types without `$.store` because the source module that supplied the
+  `Store` type no longer exists. A newly constructed simulator also sees the
+  module as absent and disables the feature. Runtime retention is a resilience
+  guarantee, not a claim that deleted source remains type-checkable.
+
+## Programmatic API
+
+When `<basePath>/_.store.ts` exists, the promise returned by `counterfact()`
+resolves with the live store alongside the existing primary `contextRegistry`:
+
+```ts
+import type { Store } from "./_.store.js";
+
+const simulator = await counterfact<Store>(config, specs);
+const { stop } = await simulator.start(config);
+
+if (simulator.store === undefined) {
+  throw new Error("Expected _.store.ts to be loaded");
+}
+
+simulator.store.seed(/* ... */);
+await stop();
+```
+
+The programmatic signature is `counterfact<TStore = unknown>(...)`, and its
+return type includes `store?: TStore`. A caller supplies the generic argument
+when it wants the concrete user-authored type. Counterfact can discover the
+module and regenerate project files, but the published TypeScript declaration
+for the general-purpose `counterfact()` function cannot infer a caller-local
+type from filesystem state. The return property is initially omitted when the
+store module does not exist and is added if a valid module is later discovered
+while watching. It is not a second context registry: once constructed, its
+identity is stable for the simulator instance's lifetime and it is usable before
+`start()` when discovered during initial construction.
+
+## Required validation
+
+The implementation MUST verify the following:
+
+1. Two different API groups observe mutations made through the same store using
+   real HTTP requests.
+2. Existing multi-spec groups remain isolated when `_.store.ts` is absent.
+3. A store reload preserves existing data while exposing updated methods.
+4. A store reload adds newly declared fields without overwriting or deleting
+   existing fields.
+5. Generated context constructor types expose the concrete store type, while
+   generated operation, middleware, and scenario types do not.
+6. The REPL and programmatic API expose the same live store used by contexts.
+   The programmatic generic types the store without making it non-optional.
+7. An invalid initial store module rejects `counterfact()` with the absolute
+   path and underlying error, while an absent module leaves the feature
+   disabled.
+8. Deleting or breaking a previously loaded store module retains the last good
+   live store and reports the failed reload to standard error.
+9. CLI and programmatic use both discover only `<basePath>/_.store.ts`; no
+   store-location configuration is accepted.
+10. Two simulator instances in one process receive independent stores, while a
+    stop/start cycle on one instance preserves its store.
+11. Store access from middleware, operation, and scenario arguments remains
+    absent at both runtime and compile time.
+12. A group startup-scenario failure after store initialization releases active
+    watchers and leaves the configured HTTP port unopened.
+13. Existing single-API behavior is unchanged when `_.store.ts` is absent.
+14. Creating `_.store.ts` while watching activates the store, updates the
+    simulator object and REPL, reloads contexts without losing their state, and
+    regenerates every group's context constructor type.
+15. Deleting a loaded store retains the running simulator's live object but
+    removes `$.store` from watched context types; constructing a new simulator
+    without the file disables the feature.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,19 +18,19 @@ New to Counterfact? Begin with the [Getting Started guide](./getting-started.md)
 
 ## Features
 
-| Feature | Description |
-|---|---|
-| [Generated code](./features/generated-code.md) | How Counterfact generates TypeScript from your OpenAPI spec |
-| [Routes](./features/routes.md) | Writing route handlers, building responses, reading request data |
-| [State (context objects)](./features/state.md) | Sharing in-memory state across routes |
-| [Hot reload](./features/hot-reload.md) | Live file updates without restarting the server |
-| [REPL](./features/repl.md) | Interactive terminal for runtime inspection and control |
-| [Proxy](./features/proxy.md) | Mix real backend calls with mocked endpoints |
-| [Middleware](./features/middleware.md) | Cross-cutting request/response logic |
-| [TypeScript native mode](./features/typescript-native-mode.md) | Run route files directly without a compilation step |
-| [Programmatic API](./features/programmatic-api.md) | Embed Counterfact in test suites with Playwright, Cypress, etc. |
-| [Without OpenAPI](./features/without-openapi.md) | Use Counterfact without an OpenAPI document |
-| [Multiple versions](./features/multiple-versions.md) | Serve multiple API versions simultaneously from a single process |
+| Feature                                                        | Description                                                      |
+| -------------------------------------------------------------- | ---------------------------------------------------------------- |
+| [Generated code](./features/generated-code.md)                 | How Counterfact generates TypeScript from your OpenAPI spec      |
+| [Routes](./features/routes.md)                                 | Writing route handlers, building responses, reading request data |
+| [State (contexts and shared store)](./features/state.md)       | Sharing in-memory state across routes and API groups             |
+| [Hot reload](./features/hot-reload.md)                         | Live file updates without restarting the server                  |
+| [REPL](./features/repl.md)                                     | Interactive terminal for runtime inspection and control          |
+| [Proxy](./features/proxy.md)                                   | Mix real backend calls with mocked endpoints                     |
+| [Middleware](./features/middleware.md)                         | Cross-cutting request/response logic                             |
+| [TypeScript native mode](./features/typescript-native-mode.md) | Run route files directly without a compilation step              |
+| [Programmatic API](./features/programmatic-api.md)             | Embed Counterfact in test suites with Playwright, Cypress, etc.  |
+| [Without OpenAPI](./features/without-openapi.md)               | Use Counterfact without an OpenAPI document                      |
+| [Multiple versions](./features/multiple-versions.md)           | Serve multiple API versions simultaneously from a single process |
 
 ---
 

--- a/src/api-runner.ts
+++ b/src/api-runner.ts
@@ -19,6 +19,7 @@ import { runtimeCanExecuteErasableTs } from "./util/runtime-can-execute-erasable
 export interface ApiRunnerGroupState {
   contextRegistry: ContextRegistry;
   scenarioRegistry: ScenarioRegistry;
+  getStore?: () => object | undefined;
 }
 
 /**
@@ -142,7 +143,10 @@ export class ApiRunner {
     this.scenarioRegistry =
       groupState?.scenarioRegistry ?? new ScenarioRegistry();
 
-    this.scenarioFileGenerator = new ScenarioFileGenerator(modulesPath);
+    this.scenarioFileGenerator = new ScenarioFileGenerator(
+      modulesPath,
+      config.basePath,
+    );
 
     this.codeGenerator = new CodeGenerator(
       this.openApiPath,
@@ -173,6 +177,7 @@ export class ApiRunner {
       this.contextRegistry,
       pathJoin(modulesPath, "scenarios"),
       this.scenarioRegistry,
+      groupState?.getStore,
     );
   }
 
@@ -257,6 +262,11 @@ export class ApiRunner {
    */
   public async load(): Promise<void> {
     await this.moduleLoader.load();
+  }
+
+  /** Reloads all context constructors for this runner's API group. */
+  public async reloadContexts(): Promise<void> {
+    await this.moduleLoader.reloadContexts();
   }
 
   /**

--- a/src/app.ts
+++ b/src/app.ts
@@ -472,6 +472,7 @@ export async function counterfact<TStore = unknown>(
         replServers.delete(replServer);
       });
       return replServer;
+    },
   };
   const result: typeof baseSimulator & { store?: TStore } = baseSimulator;
   simulatorRef.current = result;

--- a/src/app.ts
+++ b/src/app.ts
@@ -10,6 +10,7 @@ import type { Config } from "./server/config.js";
 import { ContextRegistry } from "./server/context-registry.js";
 import { createKoaApp } from "./server/web-server/create-koa-app.js";
 import { ScenarioRegistry } from "./server/scenario-registry.js";
+import { StoreLoader } from "./server/store-loader.js";
 import { Repository } from "./typescript-generator/repository.js";
 import { ensureDirectoryExists } from "./util/ensure-directory-exists.js";
 import { generateVersionsTsContent } from "./typescript-generator/versions-ts-generator.js";
@@ -232,12 +233,43 @@ function validateSpecGroups(
  *   - `startRepl()` — launches the interactive Node.js REPL connected to the
  *     live server state.
  */
-export async function counterfact(config: Config, specs?: SpecConfig[]) {
+export async function counterfact<TStore = unknown>(
+  config: Config,
+  specs?: SpecConfig[],
+) {
   const normalizedSpecs = normalizeSpecs(
     { openApiPath: config.openApiPath, prefix: config.prefix },
     specs,
   );
   validateSpecGroups(normalizedSpecs);
+
+  let runners: ApiRunner[] = [];
+  let hasStore = false;
+  const simulatorRef: { current?: { store?: TStore } } = {};
+  const replServers = new Set<ReturnType<typeof startReplServer>>();
+  const storeLoader = new StoreLoader(config.basePath, {
+    async onStoreChange(store) {
+      const isActivation = !hasStore;
+      hasStore = true;
+      if (simulatorRef.current !== undefined) {
+        simulatorRef.current.store = store as TStore;
+      }
+      for (const replServer of replServers) {
+        replServer.context.store = store;
+      }
+
+      if (isActivation) {
+        const seenGroups = new Set<string>();
+        for (const runner of runners) {
+          if (seenGroups.has(runner.group)) continue;
+          seenGroups.add(runner.group);
+          await runner.reloadContexts();
+        }
+      }
+    },
+  });
+  const initialStore = await storeLoader.load();
+  hasStore = initialStore !== undefined;
 
   // Compute the ordered versions per group (oldest first, as declared in specs).
   // This list is passed to each runner so that $.minVersion() can compare
@@ -261,6 +293,7 @@ export async function counterfact(config: Config, specs?: SpecConfig[]) {
     {
       contextRegistry: ContextRegistry;
       scenarioRegistry: ScenarioRegistry;
+      getStore: () => object | undefined;
     }
   >();
   for (const spec of normalizedSpecs) {
@@ -268,11 +301,12 @@ export async function counterfact(config: Config, specs?: SpecConfig[]) {
       stateByGroup.set(spec.group, {
         contextRegistry: new ContextRegistry(),
         scenarioRegistry: new ScenarioRegistry(),
+        getStore: () => storeLoader.store,
       });
     }
   }
 
-  const runners = await Promise.all(
+  runners = await Promise.all(
     normalizedSpecs.map((spec) =>
       ApiRunner.create(
         {
@@ -368,6 +402,10 @@ export async function counterfact(config: Config, specs?: SpecConfig[]) {
     await Promise.all(runners.map((runner) => runner.watch()));
     await Promise.all(runners.map((runner) => runner.start(options)));
 
+    if (options.startServer) {
+      await storeLoader.watch();
+    }
+
     let httpTerminator: HttpTerminator | undefined;
 
     if (options.startServer) {
@@ -376,9 +414,10 @@ export async function counterfact(config: Config, specs?: SpecConfig[]) {
       } catch (error) {
         // Startup happens after the runner watchers are active. If a scenario
         // fails, release those resources and leave the HTTP port untouched.
-        await Promise.allSettled(
-          runners.map((runner) => runner.stopWatching()),
-        );
+        await Promise.allSettled([
+          ...runners.map((runner) => runner.stopWatching()),
+          storeLoader.stopWatching(),
+        ]);
         throw error;
       }
 
@@ -393,19 +432,22 @@ export async function counterfact(config: Config, specs?: SpecConfig[]) {
 
     return {
       async stop() {
-        await Promise.all(runners.map((runner) => runner.stopWatching()));
+        await Promise.all([
+          ...runners.map((runner) => runner.stopWatching()),
+          storeLoader.stopWatching(),
+        ]);
         await httpTerminator?.terminate();
       },
     };
   }
 
-  return {
+  const baseSimulator = {
     contextRegistry: primaryRunner.contextRegistry,
     koaApp,
     registry: primaryRunner.registry,
     start,
-    startRepl: () =>
-      startReplServer(
+    startRepl: () => {
+      const replServer = startReplServer(
         primaryRunner.contextRegistry,
         primaryRunner.registry,
         {
@@ -423,6 +465,18 @@ export async function counterfact(config: Config, specs?: SpecConfig[]) {
           registry: runner.registry,
           scenarioRegistry: runner.scenarioRegistry,
         })),
-      ),
+        storeLoader.store,
+      );
+      replServers.add(replServer);
+      return replServer;
+    },
   };
+  const result: typeof baseSimulator & { store?: TStore } = baseSimulator;
+  simulatorRef.current = result;
+
+  if (initialStore !== undefined) {
+    result.store = initialStore as TStore;
+  }
+
+  return result;
 }

--- a/src/app.ts
+++ b/src/app.ts
@@ -468,8 +468,10 @@ export async function counterfact<TStore = unknown>(
         storeLoader.store,
       );
       replServers.add(replServer);
+      replServer.once("exit", () => {
+        replServers.delete(replServer);
+      });
       return replServer;
-    },
   };
   const result: typeof baseSimulator & { store?: TStore } = baseSimulator;
   simulatorRef.current = result;

--- a/src/app.ts
+++ b/src/app.ts
@@ -468,9 +468,6 @@ export async function counterfact<TStore = unknown>(
         storeLoader.store,
       );
       replServers.add(replServer);
-      replServer.once("exit", () => {
-        replServers.delete(replServer);
-      });
       return replServer;
     },
   };

--- a/src/repl/repl.ts
+++ b/src/repl/repl.ts
@@ -264,6 +264,7 @@ export function startRepl(
   openApiDocument?: OpenApiDocument,
   scenarioRegistry?: ScenarioRegistry,
   apiBindings?: ReplApiBinding[],
+  store?: object,
 ) {
   const bindings =
     apiBindings === undefined || apiBindings.length === 0
@@ -485,6 +486,10 @@ export function startRepl(
   replServer.context.routes = isMultiApi
     ? Object.fromEntries(groupedBindings.map((binding) => [binding.key, {}]))
     : {};
+
+  if (store !== undefined) {
+    replServer.context.store = store;
+  }
 
   replServer.defineCommand("scenario", {
     async action(text: string) {

--- a/src/server/module-loader.ts
+++ b/src/server/module-loader.ts
@@ -59,6 +59,8 @@ export class ModuleLoader extends EventTarget {
 
   private readonly scenarioRegistry: ScenarioRegistry | undefined;
 
+  private readonly getStore: (() => object | undefined) | undefined;
+
   private readonly dependencyGraph = new ModuleDependencyGraph();
 
   private readonly fileDiscovery: FileDiscovery;
@@ -74,6 +76,7 @@ export class ModuleLoader extends EventTarget {
     contextRegistry = new ContextRegistry(),
     scenariosPath?: string,
     scenarioRegistry?: ScenarioRegistry,
+    getStore?: () => object | undefined,
   ) {
     super();
     this.basePath = toForwardSlashPath(basePath);
@@ -84,6 +87,7 @@ export class ModuleLoader extends EventTarget {
         ? undefined
         : toForwardSlashPath(scenariosPath);
     this.scenarioRegistry = scenarioRegistry;
+    this.getStore = getStore;
     this.fileDiscovery = new FileDiscovery(this.basePath);
   }
 
@@ -205,6 +209,16 @@ export class ModuleLoader extends EventTarget {
     const files = await this.fileDiscovery.findFiles(directory);
     await Promise.all(files.map((file) => this.loadEndpoint(file)));
     await this.loadScenarios();
+  }
+
+  /** Reloads every context module without disturbing preserved live state. */
+  public async reloadContexts(): Promise<void> {
+    const files = await this.fileDiscovery.findFiles();
+    await Promise.all(
+      files
+        .filter((file) => this.isContextFile(file))
+        .map((file) => this.loadEndpoint(file)),
+    );
   }
 
   private shouldLoadScenarioFile(pathName: string): boolean {
@@ -350,6 +364,7 @@ export class ModuleLoader extends EventTarget {
 
       if (this.isContextFile(pathName) && isContextModule(endpoint)) {
         const loadContext = (path: string) => this.contextRegistry.find(path);
+        const store = this.getStore?.();
 
         const contextDir = nodePath.dirname(unescapePathForWindows(pathName));
         const readJson = async (relativePath: string): Promise<unknown> => {
@@ -379,6 +394,7 @@ export class ModuleLoader extends EventTarget {
           new endpoint.Context({
             loadContext,
             readJson,
+            ...(store === undefined ? {} : { store }),
           }),
         );
         return;

--- a/src/server/store-loader.ts
+++ b/src/server/store-loader.ts
@@ -1,0 +1,239 @@
+import { access } from "node:fs/promises";
+import path from "node:path";
+
+import { type FSWatcher, watch } from "chokidar";
+
+import { waitForEvent } from "../util/wait-for-event.js";
+import { CHOKIDAR_OPTIONS } from "./constants.js";
+import { determineModuleKind } from "./determine-module-kind.js";
+import { uncachedImport } from "./uncached-import.js";
+
+const { uncachedRequire } = await import("./uncached-require.cjs");
+
+type Store = object;
+
+interface StoreModule {
+  Store: new () => Store;
+}
+
+export interface StoreLoaderCallbacks {
+  onSourcePresenceChange?: (present: boolean) => Promise<void> | void;
+  onStoreChange?: (store: Store) => Promise<void> | void;
+}
+
+/**
+ * Loads and watches the conventional application-level `_.store.ts` module.
+ * A successfully loaded store keeps its identity for this loader's lifetime.
+ */
+export class StoreLoader {
+  public readonly sourcePath: string;
+
+  public store: Store | undefined;
+
+  private readonly callbacks: StoreLoaderCallbacks;
+
+  private initialized = false;
+
+  private sourcePresent = false;
+
+  private watcher: FSWatcher | undefined;
+
+  private eventQueue: Promise<void> = Promise.resolve();
+
+  public constructor(basePath: string, callbacks: StoreLoaderCallbacks = {}) {
+    this.sourcePath = path.resolve(basePath, "_.store.ts");
+    this.callbacks = callbacks;
+  }
+
+  /**
+   * Performs the initial load. An absent source is a supported, disabled state.
+   */
+  public async load(): Promise<Store | undefined> {
+    if (this.initialized) return this.store;
+
+    if (!(await this.fileExists())) {
+      this.sourcePresent = false;
+      this.initialized = true;
+      return undefined;
+    }
+
+    this.sourcePresent = true;
+    const candidate = await this.importCandidate();
+    this.store = candidate;
+    this.initialized = true;
+    return candidate;
+  }
+
+  /** Watches the exact conventional path, including while it is absent. */
+  public async watch(): Promise<void> {
+    if (this.watcher !== undefined) return;
+
+    this.watcher = watch(this.sourcePath, {
+      ...CHOKIDAR_OPTIONS,
+      awaitWriteFinish: { pollInterval: 10, stabilityThreshold: 50 },
+    }).on("all", (eventName: string) => {
+      if (
+        eventName !== "add" &&
+        eventName !== "change" &&
+        eventName !== "unlink"
+      ) {
+        return;
+      }
+
+      this.enqueue(async () => {
+        await this.handleWatchEvent(eventName);
+      });
+    });
+
+    await waitForEvent(this.watcher, "ready");
+
+    // Reconcile after the initial scan because ignoreInitial deliberately
+    // suppresses add events. This also closes the load-to-watch race.
+    this.enqueue(async () => {
+      await this.reconcileAfterReady();
+    });
+    await this.eventQueue;
+  }
+
+  /** Stops the watcher after all already-received events have settled. */
+  public async stopWatching(): Promise<void> {
+    const watcher = this.watcher;
+    this.watcher = undefined;
+    await watcher?.close();
+    await this.eventQueue;
+  }
+
+  private enqueue(operation: () => Promise<void>): void {
+    this.eventQueue = this.eventQueue
+      .then(operation)
+      .catch((error: unknown) => {
+        this.writeDiagnostic(error);
+      });
+  }
+
+  private async handleWatchEvent(
+    eventName: "add" | "change" | "unlink",
+  ): Promise<void> {
+    if (eventName === "unlink") {
+      await this.updateSourcePresence(false);
+      this.initialized = true;
+      if (this.store !== undefined) {
+        throw new Error("the store source was deleted");
+      }
+      return;
+    }
+
+    await this.updateSourcePresence(true);
+    const candidate = await this.importCandidate();
+    await this.applyCandidate(candidate);
+    this.initialized = true;
+  }
+
+  private async reconcileAfterReady(): Promise<void> {
+    const present = await this.fileExists();
+
+    if (this.initialized && present === this.sourcePresent) return;
+
+    if (!present) {
+      await this.updateSourcePresence(false);
+      this.initialized = true;
+      return;
+    }
+
+    await this.updateSourcePresence(true);
+    const candidate = await this.importCandidate();
+    await this.applyCandidate(candidate);
+    this.initialized = true;
+  }
+
+  private async updateSourcePresence(present: boolean): Promise<void> {
+    if (present === this.sourcePresent) return;
+    this.sourcePresent = present;
+    await this.callbacks.onSourcePresenceChange?.(present);
+  }
+
+  private async applyCandidate(candidate: Store): Promise<void> {
+    if (this.store === undefined) {
+      this.store = candidate;
+      await this.callbacks.onStoreChange?.(candidate);
+      return;
+    }
+
+    const liveStore = this.store;
+    const newFields = Object.keys(candidate).filter(
+      (key) => !Object.hasOwn(liveStore, key),
+    );
+    if (newFields.length > 0 && !Object.isExtensible(liveStore)) {
+      throw new TypeError("the live store is not extensible");
+    }
+
+    const oldPrototype = Object.getPrototypeOf(liveStore) as object | null;
+    const newPrototype = Object.getPrototypeOf(candidate) as object | null;
+    const addedFields: string[] = [];
+
+    try {
+      Object.setPrototypeOf(liveStore, newPrototype);
+      for (const key of newFields) {
+        Object.defineProperty(liveStore, key, {
+          configurable: true,
+          enumerable: true,
+          value: Reflect.get(candidate, key),
+          writable: true,
+        });
+        addedFields.push(key);
+      }
+    } catch (error: unknown) {
+      for (const key of addedFields) {
+        Reflect.deleteProperty(liveStore, key);
+      }
+      Object.setPrototypeOf(liveStore, oldPrototype);
+      throw error;
+    }
+
+    await this.callbacks.onStoreChange?.(liveStore);
+  }
+
+  private async importCandidate(): Promise<Store> {
+    try {
+      const doImport =
+        (await determineModuleKind(this.sourcePath)) === "commonjs"
+          ? uncachedRequire
+          : uncachedImport;
+      const imported = (await doImport(
+        this.sourcePath,
+      )) as Partial<StoreModule>;
+
+      if (typeof imported.Store !== "function") {
+        throw new TypeError('the module must export a constructable "Store"');
+      }
+
+      return new imported.Store();
+    } catch (error: unknown) {
+      throw this.createLoadError(error);
+    }
+  }
+
+  private createLoadError(error: unknown): Error {
+    const details = error instanceof Error ? error.message : String(error);
+    return new Error(
+      `Could not load store from "${this.sourcePath}": ${details}`,
+      { cause: error },
+    );
+  }
+
+  private writeDiagnostic(error: unknown): void {
+    const details = error instanceof Error ? error.message : String(error);
+    process.stderr.write(
+      `Store reload failed for "${this.sourcePath}"; retaining the last good store. ${details}\n`,
+    );
+  }
+
+  private async fileExists(): Promise<boolean> {
+    try {
+      await access(this.sourcePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/src/server/uncached-import.ts
+++ b/src/server/uncached-import.ts
@@ -1,9 +1,11 @@
 import { pathToFileURL } from "node:url";
 
+let cacheBustSequence = 0;
+
 export async function uncachedImport(pathName: string) {
   const fileUrl = `${pathToFileURL(
     pathName,
-  ).toString()}?cacheBust=${Date.now()}`;
+  ).toString()}?cacheBust=${Date.now()}-${cacheBustSequence++}`;
 
   return await import(fileUrl);
 }

--- a/src/typescript-generator/scenario-file-generator.ts
+++ b/src/typescript-generator/scenario-file-generator.ts
@@ -107,7 +107,10 @@ function buildLoadContextOverload(routePath: string, alias: string): string {
   return `  loadContext(path: \`${templatePath}\`): ${alias};`;
 }
 
-function buildScenarioContextContent(contextFiles: ContextFileInfo[]): string {
+function buildScenarioContextContent(
+  contextFiles: ContextFileInfo[],
+  storeImportPath?: string,
+): string {
   const rootContext = contextFiles.find((f) => f.routePath === "/");
   const contextType = rootContext
     ? rootContext.alias
@@ -118,6 +121,9 @@ function buildScenarioContextContent(contextFiles: ContextFileInfo[]): string {
       ? `import type { Context } from "${importPath}";`
       : `import type { Context as ${alias} } from "${importPath}";`,
   );
+  if (storeImportPath !== undefined) {
+    importLines.push(`import type { Store } from "${storeImportPath}";`);
+  }
 
   const overloadLines = contextFiles.map(({ alias, routePath }) =>
     buildLoadContextOverload(routePath, alias),
@@ -148,6 +154,12 @@ function buildScenarioContextContent(contextFiles: ContextFileInfo[]): string {
     "",
     "/** Interface for Context objects defined in _.context.ts files */",
     "export interface Context$ {",
+    ...(storeImportPath === undefined
+      ? []
+      : [
+          "  /** Application-level store shared by every API group */",
+          "  readonly store: Store;",
+        ]),
     "  /** Load a context object for a specific path */",
     '  readonly loadContext: LoadContextDefinitions["loadContext"];',
     "  /** Load a JSON file relative to this file's path */",
@@ -168,13 +180,22 @@ function buildScenarioContextContent(contextFiles: ContextFileInfo[]): string {
  * every route path that has a context file.
  *
  * @param destination - Root output directory.
+ * @param rootDestination - Application root containing the optional store.
  */
-async function writeScenarioContextType(destination: string): Promise<void> {
+async function writeScenarioContextType(
+  destination: string,
+  rootDestination: string,
+): Promise<void> {
   const typesDir = nodePath.join(destination, "types");
   const filePath = nodePath.join(typesDir, "_.context.ts");
+  const storePath = nodePath.join(rootDestination, "_.store.ts");
 
   const contextFiles = await collectContextFiles(destination);
-  const content = buildScenarioContextContent(contextFiles);
+  const relativeStorePath = pathRelative(typesDir, storePath);
+  const storeImportPath = existsSync(storePath)
+    ? `${relativeStorePath.startsWith(".") ? "" : "./"}${relativeStorePath.replace(/\.ts$/u, ".js")}`
+    : undefined;
+  const content = buildScenarioContextContent(contextFiles, storeImportPath);
 
   await fs.mkdir(typesDir, { recursive: true });
   await fs.writeFile(filePath, content, "utf8");
@@ -255,48 +276,71 @@ async function writeDefaultScenariosIndex(destination: string): Promise<void> {
  * - `scenarios/index.ts` — the default scenarios entry-point (created only if
  *   it does not already exist).
  *
- * When {@link watch} is called, a file-system watcher monitors the `routes/`
- * directory for changes to `_.context.ts` files and automatically regenerates
- * `types/_.context.ts`.
+ * When {@link watch} is called, file-system watchers monitor the `routes/`
+ * directory for changes to `_.context.ts` files and the application root's
+ * optional `_.store.ts`, automatically regenerating `types/_.context.ts`.
  */
 export class ScenarioFileGenerator {
   private readonly destination: string;
 
+  private readonly rootDestination: string;
+
   private watcher: FSWatcher | undefined;
 
-  public constructor(destination: string) {
+  private storeWatcher: FSWatcher | undefined;
+
+  public constructor(destination: string, rootDestination = destination) {
     this.destination = destination;
+    this.rootDestination = rootDestination;
   }
 
   /** Generates both scenario-related files once and resolves when complete. */
   public async generate(): Promise<void> {
-    await writeScenarioContextType(this.destination);
+    await writeScenarioContextType(this.destination, this.rootDestination);
     await writeDefaultScenariosIndex(this.destination);
   }
 
   /**
-   * Starts watching the `routes/` directory for `_.context.ts` changes and
-   * regenerates `types/_.context.ts` on every change.
+   * Starts watching route context files and the exact application-root store
+   * path, regenerating `types/_.context.ts` on every relevant change.
    *
    * Resolves once the watcher is ready.
    */
   public async watch(): Promise<void> {
     const routesDir = nodePath.join(this.destination, "routes");
+    const storePath = nodePath.join(this.rootDestination, "_.store.ts");
+    const regenerate = (): void => {
+      void writeScenarioContextType(this.destination, this.rootDestination);
+    };
 
     this.watcher = watch(routesDir, CHOKIDAR_OPTIONS).on(
       "all",
       (_event, filePath: string) => {
         if (filePath.endsWith("_.context.ts")) {
-          void writeScenarioContextType(this.destination);
+          regenerate();
         }
       },
     );
 
-    await waitForEvent(this.watcher, "ready");
+    // Polling lets chokidar observe creation of the exact conventional store
+    // path even when the file is absent when the watcher starts.
+    this.storeWatcher = watch(storePath, {
+      ...CHOKIDAR_OPTIONS,
+      usePolling: true,
+    }).on("all", (_event, filePath: string) => {
+      if (nodePath.resolve(filePath) === nodePath.resolve(storePath)) {
+        regenerate();
+      }
+    });
+
+    await Promise.all([
+      waitForEvent(this.watcher, "ready"),
+      waitForEvent(this.storeWatcher, "ready"),
+    ]);
   }
 
   /** Closes the file-system watcher. */
   public async stopWatching(): Promise<void> {
-    await this.watcher?.close();
+    await Promise.all([this.watcher?.close(), this.storeWatcher?.close()]);
   }
 }

--- a/test/app-types.test.ts
+++ b/test/app-types.test.ts
@@ -1,0 +1,41 @@
+import { counterfact } from "../src/app.js";
+
+interface ConcreteStore {
+  readonly count: number;
+  increment(): void;
+}
+
+type GenericSimulator = Awaited<ReturnType<typeof counterfact<ConcreteStore>>>;
+type DefaultSimulator = Awaited<ReturnType<typeof counterfact>>;
+type IsEqual<Left, Right> =
+  (<Value>() => Value extends Left ? 1 : 2) extends <
+    Value,
+  >() => Value extends Right ? 1 : 2
+    ? true
+    : false;
+type IsOptional<ObjectType, Key extends keyof ObjectType> =
+  object extends Pick<ObjectType, Key> ? true : false;
+
+describe("counterfact store return type", () => {
+  it("is optional, uses the supplied generic, and defaults to unknown", () => {
+    const genericStoreType: IsEqual<
+      GenericSimulator["store"],
+      ConcreteStore | undefined
+    > = true;
+    const genericStoreIsOptional: IsOptional<GenericSimulator, "store"> = true;
+    const defaultStoreType: IsEqual<DefaultSimulator["store"], unknown> = true;
+    const defaultStoreIsOptional: IsOptional<DefaultSimulator, "store"> = true;
+
+    expect({
+      defaultStoreIsOptional,
+      defaultStoreType,
+      genericStoreIsOptional,
+      genericStoreType,
+    }).toEqual({
+      defaultStoreIsOptional: true,
+      defaultStoreType: true,
+      genericStoreIsOptional: true,
+      genericStoreType: true,
+    });
+  });
+});

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -8,6 +8,7 @@ import * as app from "../src/app";
 import { ApiRunner } from "../src/api-runner";
 import { ContextRegistry } from "../src/server/context-registry";
 import { ScenarioRegistry } from "../src/server/scenario-registry";
+import { StoreLoader } from "../src/server/store-loader";
 
 // Minimal valid mock Config
 const mockConfig = {
@@ -25,7 +26,269 @@ const mockConfig = {
   prefix: "",
 };
 
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+
+  throw new Error("Condition was not met within five seconds");
+}
+
 describe("counterfact", () => {
+  it("shares store mutations across API groups through real HTTP requests", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        "export class Store { customers = new Set(); }",
+      );
+      await $.add(
+        "customers/routes/_.context.js",
+        "export class Context { constructor({ store }) { this.store = store; } add(id) { this.store.customers.add(id); } }",
+      );
+      await $.add(
+        "customers/routes/customers.js",
+        "export function POST($) { $.context.add($.body.id); return { body: { size: $.context.store.customers.size } }; }",
+      );
+      await $.add(
+        "orders/routes/_.context.js",
+        "export class Context { constructor({ store }) { this.store = store; } customerIds() { return [...this.store.customers]; } }",
+      );
+      await $.add(
+        "orders/routes/orders.js",
+        "export function GET($) { return { body: { customerIds: $.context.customerIds() } }; }",
+      );
+
+      const simulator = await app.counterfact(
+        { ...mockConfig, basePath: $.path("."), port: 0 },
+        [
+          { source: "_", prefix: "/customers-api", group: "customers" },
+          { source: "_", prefix: "/orders-api", group: "orders" },
+        ],
+      );
+      const { stop } = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+
+      try {
+        const mutation = await request(simulator.koaApp.callback())
+          .post("/customers-api/customers")
+          .send({ id: "customer-1" });
+        const observation = await request(simulator.koaApp.callback()).get(
+          "/orders-api/orders",
+        );
+
+        expect(mutation.body).toEqual({ size: 1 });
+        expect(observation.body).toEqual({ customerIds: ["customer-1"] });
+      } finally {
+        await stop();
+      }
+    });
+  });
+
+  it("keeps stores independent between simulator instances", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        "export class Store { count = 0; increment() { this.count += 1; } }",
+      );
+
+      const first = await app.counterfact<{ count: number; increment(): void }>(
+        { ...mockConfig, basePath: $.path("."), port: 0 },
+      );
+      const second = await app.counterfact<{
+        count: number;
+        increment(): void;
+      }>({ ...mockConfig, basePath: $.path("."), port: 0 });
+
+      first.store?.increment();
+
+      expect(first.store).not.toBe(second.store);
+      expect(first.store?.count).toBe(1);
+      expect(second.store?.count).toBe(0);
+    });
+  });
+
+  it("omits an absent store and rejects an invalid initial store at the app boundary", async () => {
+    await usingTemporaryFiles(async ($) => {
+      const withoutStore = await app.counterfact({
+        ...mockConfig,
+        basePath: $.path("."),
+      });
+      expect(Object.hasOwn(withoutStore, "store")).toBe(false);
+
+      await $.add("_.store.ts", "export const Store = 42;");
+      await expect(
+        app.counterfact({ ...mockConfig, basePath: $.path(".") }),
+      ).rejects.toThrow($.path("_.store.ts"));
+    });
+  });
+
+  it("keeps the store off operation, middleware, and scenario arguments", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("_.store.ts", 'export class Store { marker = "shared"; }');
+      await $.add(
+        "routes/_.context.js",
+        "export class Context { constructor({ store }) { this.store = store; this.scenarioHasStore = undefined; } }",
+      );
+      await $.add(
+        "routes/boundary.js",
+        'export function GET($) { return { body: { contextStore: $.context.store.marker, operationHasStore: Object.hasOwn($, "store"), scenarioHasStore: $.context.scenarioHasStore } }; }',
+      );
+      await $.add(
+        "scenarios/index.js",
+        'export function startup($) { $.context.scenarioHasStore = Object.hasOwn($, "store"); }',
+      );
+
+      const simulator = await app.counterfact({
+        ...mockConfig,
+        basePath: $.path("."),
+        port: 0,
+      });
+      let middlewareHasStore: boolean | undefined;
+      simulator.registry.addMiddleware("/", async ($, respondTo) => {
+        middlewareHasStore = Object.hasOwn($, "store");
+        return respondTo($);
+      });
+      const { stop } = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+
+      try {
+        const response = await request(simulator.koaApp.callback()).get(
+          "/boundary",
+        );
+        expect(response.body).toEqual({
+          contextStore: "shared",
+          operationHasStore: false,
+          scenarioHasStore: false,
+        });
+        expect(middlewareHasStore).toBe(false);
+      } finally {
+        await stop();
+      }
+    });
+  });
+
+  it("loads one shared store before startup and keeps it across stop/start", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        "export class Store { count = 0; increment() { this.count += 1 } }",
+      );
+      await $.add("routes/index.js", "export function GET() { return {} }");
+
+      const simulator = await app.counterfact<{
+        count: number;
+        increment(): void;
+      }>({ ...mockConfig, basePath: $.path("."), port: 0 });
+      const store = simulator.store;
+
+      expect(store).toBeDefined();
+      store?.increment();
+      const firstRun = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+      await firstRun.stop();
+      const secondRun = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+
+      expect(simulator.store).toBe(store);
+      expect(simulator.store?.count).toBe(1);
+      await secondRun.stop();
+    });
+  });
+
+  it("updates an already-open REPL when a store is activated", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("routes/index.js", "export function GET() { return {} }");
+      const simulator = await app.counterfact<{ active: boolean }>({
+        ...mockConfig,
+        basePath: $.path("."),
+        port: 0,
+      });
+      const replServer = simulator.startRepl();
+      const { stop } = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+      try {
+        expect(replServer.context["store"]).toBeUndefined();
+        await $.add("_.store.ts", "export class Store { active = true }");
+
+        await waitUntil(() => replServer.context["store"] !== undefined);
+
+        expect(simulator.store).toMatchObject({ active: true });
+        expect(replServer.context["store"]).toBe(simulator.store);
+      } finally {
+        replServer.close();
+        await stop();
+      }
+    });
+  });
+
+  it("activates a store without losing context state and retains it after breakage or deletion", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "routes/_.context.js",
+        "export class Context { constructor($) { this.store = $.store; this.count = 0; } increment() { this.count += 1; } }",
+      );
+      await $.add(
+        "routes/state.js",
+        "export function POST($) { $.context.increment(); return { body: { count: $.context.count } }; } export function GET($) { return { body: { count: $.context.count, storeMarker: $.context.store?.marker } }; }",
+      );
+      const stderr = jest.spyOn(process.stderr, "write").mockReturnValue(true);
+      const simulator = await app.counterfact<{ marker: string }>({
+        ...mockConfig,
+        basePath: $.path("."),
+        port: 0,
+      });
+      const { stop } = await simulator.start({
+        ...mockConfig,
+        startServer: true,
+      });
+
+      try {
+        await request(simulator.koaApp.callback()).post("/state");
+        await $.add("_.store.ts", 'export class Store { marker = "live"; }');
+        await waitUntil(() => simulator.store !== undefined);
+
+        const liveStore = simulator.store;
+        const afterActivation = await request(simulator.koaApp.callback()).get(
+          "/state",
+        );
+        expect(liveStore).toMatchObject({ marker: "live" });
+        expect(afterActivation.body).toEqual({
+          count: 1,
+          storeMarker: "live",
+        });
+
+        jest.resetModules();
+        await $.add("_.store.ts", 'throw new Error("broken while live")');
+        await waitUntil(() => stderr.mock.calls.length >= 1);
+        expect(simulator.store).toBe(liveStore);
+        expect(stderr).toHaveBeenLastCalledWith(
+          expect.stringContaining("broken while live"),
+        );
+
+        await $.remove("_.store.ts");
+        await waitUntil(() => stderr.mock.calls.length >= 2);
+        expect(simulator.store).toBe(liveStore);
+        expect(stderr).toHaveBeenLastCalledWith(
+          expect.stringContaining("deleted"),
+        );
+      } finally {
+        await stop();
+        stderr.mockRestore();
+      }
+    });
+  });
+
   it("returns a startRepl function", async () => {
     const result = await (app as any).counterfact(mockConfig);
     expect(typeof result.startRepl).toBe("function");
@@ -575,6 +838,10 @@ describe("counterfact", () => {
       const stopWatchingSpy = jest
         .spyOn(ApiRunner.prototype, "stopWatching")
         .mockResolvedValue(undefined);
+      const storeStopWatchingSpy = jest.spyOn(
+        StoreLoader.prototype,
+        "stopWatching",
+      );
 
       const result = await (app as any).counterfact(
         { ...mockConfig, basePath: $.path("."), port: 0 },
@@ -604,8 +871,10 @@ describe("counterfact", () => {
       );
       expect(listenSpy).not.toHaveBeenCalled();
       expect(stopWatchingSpy).toHaveBeenCalledTimes(2);
+      expect(storeStopWatchingSpy).toHaveBeenCalledTimes(1);
 
       listenSpy.mockRestore();
+      storeStopWatchingSpy.mockRestore();
       stopWatchingSpy.mockRestore();
       runnerStartSpy.mockRestore();
       createSpy.mockRestore();

--- a/test/repl/repl.test.ts
+++ b/test/repl/repl.test.ts
@@ -69,6 +69,7 @@ class ReplHarness {
     config: Config,
     scenarioRegistry?: ScenarioRegistry,
     apiBindings?: ReplApiBinding[],
+    store?: object,
   ) {
     this.server = startRepl(
       contextRegistry,
@@ -78,6 +79,7 @@ class ReplHarness {
       undefined,
       scenarioRegistry,
       apiBindings,
+      store,
     );
   }
 
@@ -100,6 +102,7 @@ class ReplHarness {
 function createHarness(
   scenarioRegistry?: ScenarioRegistry,
   apiBindings?: ReplApiBinding[],
+  store?: object,
 ) {
   const contextRegistry = new ContextRegistry();
   const registry = new Registry();
@@ -113,6 +116,7 @@ function createHarness(
     config,
     scenarioRegistry,
     apiBindings,
+    store,
   );
 
   openServers.push(harness.server);
@@ -316,6 +320,13 @@ describe("REPL", () => {
         "/pets/{petId}",
       ).path({ petId: 1 }),
     ).toBeDefined();
+  });
+
+  it("exposes the shared store as an unqualified binding", () => {
+    const store = { customers: new Map([["1", { name: "Ada" }]]) };
+    const { harness } = createHarness(undefined, undefined, store);
+
+    expect(harness.server.context["store"]).toBe(store);
   });
 
   it("exposes grouped context/route/routes for multi-runner mode", () => {

--- a/test/server/module-loader.test.ts
+++ b/test/server/module-loader.test.ts
@@ -273,6 +273,63 @@ describe("a module loader", () => {
     });
   });
 
+  it("injects the shared store only when constructing contexts", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.context.js",
+        "export class Context { constructor($) { this.receivedStore = $.store; this.count = 0 } }",
+      );
+      await $.add("package.json", '{ "type": "module" }');
+
+      const store = { shared: true };
+      const contextRegistry = new ContextRegistry();
+      const loader = new ModuleLoader(
+        $.path("."),
+        new Registry(),
+        contextRegistry,
+        undefined,
+        undefined,
+        () => store,
+      );
+
+      await loader.load();
+
+      expect(contextRegistry.find("/").receivedStore).toBe(store);
+    });
+  });
+
+  it("reloads contexts with a newly activated store while preserving state", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.context.js",
+        "export class Context { constructor($) { this.store = $.store; this.count = 0 } }",
+      );
+      await $.add("package.json", '{ "type": "module" }');
+
+      const storeRef: { current?: object } = {};
+      const contextRegistry = new ContextRegistry();
+      const loader = new ModuleLoader(
+        $.path("."),
+        new Registry(),
+        contextRegistry,
+        undefined,
+        undefined,
+        () => storeRef.current,
+      );
+
+      await loader.load();
+      const context = contextRegistry.find("/");
+      context.count = 7;
+      storeRef.current = { activated: true };
+
+      await loader.reloadContexts();
+
+      expect(contextRegistry.find("/")).toBe(context);
+      expect(context.count).toBe(7);
+      expect(context.store).toBe(storeRef.current);
+    });
+  });
+
   it("provides readJson for reading JSON files relative to the context file", async () => {
     await usingTemporaryFiles(async ($) => {
       await $.add("data.json", '{"name": "test", "value": 42}');

--- a/test/server/store-loader.test.ts
+++ b/test/server/store-loader.test.ts
@@ -153,7 +153,10 @@ function eventTargetForCallback(callback: jest.Mock): Promise<void> {
 }
 
 async function waitForMock(mock: jest.Mock, calls: number): Promise<void> {
-  while (mock.mock.calls.length < calls) {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (mock.mock.calls.length >= calls) return;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
+
+  throw new Error(`Mock was not called ${calls} times within five seconds`);
 }

--- a/test/server/store-loader.test.ts
+++ b/test/server/store-loader.test.ts
@@ -1,0 +1,159 @@
+import { jest } from "@jest/globals";
+import { usingTemporaryFiles } from "using-temporary-files";
+
+import { StoreLoader } from "../../src/server/store-loader.js";
+
+describe("StoreLoader", () => {
+  it("uses the absolute conventional path and treats an absent source as disabled", async () => {
+    await usingTemporaryFiles(async ($) => {
+      const loader = new StoreLoader($.path("."));
+
+      await expect(loader.load()).resolves.toBeUndefined();
+      expect(loader.store).toBeUndefined();
+      expect(loader.sourcePath).toBe($.path("_.store.ts"));
+    });
+  });
+
+  it("constructs exactly one live store during an idempotent initial load", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        "export class Store { count = 1; constructor() { globalThis.__storeConstructions = (globalThis.__storeConstructions ?? 0) + 1; } }",
+      );
+      Reflect.set(globalThis, "__storeConstructions", 0);
+      const loader = new StoreLoader($.path("."));
+
+      const first = await loader.load();
+      const second = await loader.load();
+
+      expect(first).toBe(second);
+      expect(Reflect.get(globalThis, "__storeConstructions")).toBe(1);
+      Reflect.deleteProperty(globalThis, "__storeConstructions");
+    });
+  });
+
+  it.each([
+    ["has no Store export", "export const value = 1", "must export"],
+    ["throws while loading", 'throw new Error("module boom")', "module boom"],
+    [
+      "throws while constructing",
+      'export class Store { constructor() { throw new Error("constructor boom") } }',
+      "constructor boom",
+    ],
+  ])("rejects when the initial module %s", async (_name, source, message) => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("_.store.ts", source);
+      const loader = new StoreLoader($.path("."));
+
+      await expect(loader.load()).rejects.toThrow(message);
+      await expect(loader.load()).rejects.toThrow($.path("_.store.ts"));
+      expect(loader.store).toBeUndefined();
+    });
+  });
+
+  it("preserves identity and state while updating methods and adding only new own fields", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        'export class Store { retained = "initial"; removed = "keep"; method() { return "old" } }',
+      );
+      const onStoreChange = jest.fn();
+      const loader = new StoreLoader($.path("."), { onStoreChange });
+      const store = (await loader.load()) as Record<string, unknown> & {
+        method(): string;
+      };
+      store.retained = "runtime";
+      await loader.watch();
+
+      const changed = eventTargetForCallback(onStoreChange);
+      jest.resetModules();
+      await $.add(
+        "_.store.ts",
+        'export class Store { retained = "replacement"; added = 42; method() { return "new" } }',
+      );
+      await changed;
+
+      expect(loader.store).toBe(store);
+      expect(store).toMatchObject({
+        added: 42,
+        removed: "keep",
+        retained: "runtime",
+      });
+      expect(store.method()).toBe("new");
+      await loader.stopWatching();
+    });
+  });
+
+  it("activates when the initially absent exact source is added", async () => {
+    await usingTemporaryFiles(async ($) => {
+      const onStoreChange = jest.fn();
+      const onSourcePresenceChange = jest.fn();
+      const loader = new StoreLoader($.path("."), {
+        onSourcePresenceChange,
+        onStoreChange,
+      });
+
+      await loader.load();
+      await loader.watch();
+      const changed = eventTargetForCallback(onStoreChange);
+      await $.add("_.store.ts", "export class Store { active = true }");
+      await changed;
+
+      expect(loader.store).toMatchObject({ active: true });
+      expect(onSourcePresenceChange).toHaveBeenCalledWith(true);
+      await loader.stopWatching();
+    });
+  });
+
+  it("retains the last good store and reports broken reloads and deletion", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        'export class Store { value = "saved"; method() { return "good" } }',
+      );
+      const stderr = jest.spyOn(process.stderr, "write").mockReturnValue(true);
+      const onSourcePresenceChange = jest.fn();
+      const loader = new StoreLoader($.path("."), { onSourcePresenceChange });
+      const store = (await loader.load()) as {
+        method(): string;
+        value: string;
+      };
+      await loader.watch();
+
+      jest.resetModules();
+      await $.add("_.store.ts", 'throw new Error("reload boom")');
+      await waitForMock(stderr, 1);
+      expect(loader.store).toBe(store);
+      expect(store.method()).toBe("good");
+      expect(stderr).toHaveBeenLastCalledWith(
+        expect.stringContaining(`${$.path("_.store.ts")}"; retaining`),
+      );
+      expect(stderr).toHaveBeenLastCalledWith(
+        expect.stringContaining("reload boom"),
+      );
+
+      await $.remove("_.store.ts");
+      await waitForMock(stderr, 2);
+      expect(loader.store).toBe(store);
+      expect(onSourcePresenceChange).toHaveBeenLastCalledWith(false);
+      expect(stderr).toHaveBeenLastCalledWith(
+        expect.stringContaining("deleted"),
+      );
+
+      await loader.stopWatching();
+      stderr.mockRestore();
+    });
+  });
+});
+
+function eventTargetForCallback(callback: jest.Mock): Promise<void> {
+  return new Promise((resolve) => {
+    callback.mockImplementationOnce(() => resolve());
+  });
+}
+
+async function waitForMock(mock: jest.Mock, calls: number): Promise<void> {
+  while (mock.mock.calls.length < calls) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}

--- a/test/typescript-generator/generate.test.ts
+++ b/test/typescript-generator/generate.test.ts
@@ -4,6 +4,21 @@ import { CodeGenerator } from "../../src/typescript-generator/code-generator.js"
 import { ScenarioFileGenerator } from "../../src/typescript-generator/scenario-file-generator.js";
 import { Repository } from "../../src/typescript-generator/repository.js";
 
+async function waitForGeneratedContent(
+  read: () => Promise<string>,
+  predicate: (content: string) => boolean,
+): Promise<string> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const content = await read();
+    if (predicate(content)) {
+      return content;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  throw new Error("Generated content did not update within five seconds");
+}
+
 describe("end-to-end test", () => {
   it("generates the same code for pet store that it did on the last test run", async () => {
     await usingTemporaryFiles(async ($) => {
@@ -583,6 +598,77 @@ describe("_.context type generation", () => {
       expect(content).toContain(
         "loadContext(path: string): Record<string, unknown>;",
       );
+    });
+  });
+
+  it("adds the root store only to the context constructor type", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("_.store.ts", "export class Store {}");
+
+      await new ScenarioFileGenerator($.path("")).generate();
+
+      const content = await $.read("types/_.context.ts");
+      expect(content).toContain('import type { Store } from "../_.store.js";');
+      expect(content).toContain("export interface Context$ {");
+      expect(content).toContain("  readonly store: Store;");
+
+      const scenarioType = content.slice(
+        content.indexOf("export interface Scenario$"),
+        content.indexOf("export type Scenario"),
+      );
+      expect(scenarioType).not.toContain("readonly store:");
+    });
+  });
+
+  it("imports the root store type from a nested API group", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("_.store.ts", "export class Store {}");
+
+      await new ScenarioFileGenerator(
+        $.path("groups/customers"),
+        $.path(""),
+      ).generate();
+
+      const content = await $.read("groups/customers/types/_.context.ts");
+      expect(content).toContain(
+        'import type { Store } from "../../../_.store.js";',
+      );
+      expect(content).toContain("  readonly store: Store;");
+    });
+  });
+
+  it("watches an initially absent root store and regenerates on add and delete", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.addDirectory("customers/routes");
+      const generator = new ScenarioFileGenerator(
+        $.path("customers"),
+        $.path(""),
+      );
+
+      await generator.generate();
+      await generator.watch();
+
+      try {
+        expect(await $.read("customers/types/_.context.ts")).not.toContain(
+          "readonly store: Store;",
+        );
+
+        await $.add("_.store.ts", "export class Store {}");
+        const contentAfterAdd = await waitForGeneratedContent(
+          () => $.read("customers/types/_.context.ts"),
+          (content) => content.includes("readonly store: Store;"),
+        );
+        expect(contentAfterAdd).toContain("readonly store: Store;");
+
+        await $.remove("_.store.ts");
+        const contentAfterDelete = await waitForGeneratedContent(
+          () => $.read("customers/types/_.context.ts"),
+          (content) => !content.includes("readonly store: Store;"),
+        );
+        expect(contentAfterDelete).not.toContain("readonly store: Store;");
+      } finally {
+        await generator.stopWatching();
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Add an opt-in application-level store at `<basePath>/_.store.ts`.
- Expose the live store to typed route contexts, the REPL, and the programmatic API.
- Preserve store identity and existing data across hot reloads, stop/start cycles, and failed reloads.
- Generate and watch concrete store types for every API group's context constructor.
- Add lifecycle, reload, cross-group HTTP, boundary, and generic typing coverage.
- Document the feature with a new shared-store usage pattern and related links.

## Validation

- Full Jest suite: 62 suites, 895 tests passed, 127 snapshots.
- Coverage thresholds passed.
- Build and type-definition tests passed.
- Lint passed with 0 errors; existing warnings remain.
- Markdown formatting and relative documentation links validated.