### PR TITLE
Fix wide route random response typing

### DIFF
--- a/.changeset/fix-wide-route-response-types.md
+++ b/.changeset/fix-wide-route-response-types.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Fix type checking for fluent response helpers in wide route handlers.

--- a/src/counterfact-types/wide-operation-argument.ts
+++ b/src/counterfact-types/wide-operation-argument.ts
@@ -1,3 +1,4 @@
+import type { HttpStatusCode } from "./http-status-code.js";
 import type { WideResponseBuilder } from "./wide-response-builder.js";
 
 /**
@@ -13,5 +14,7 @@ export interface WideOperationArgument {
   path: { [key: string]: string };
   proxy: (url: string) => { proxyUrl: string };
   query: { [key: string]: string };
-  response: { [key: number]: WideResponseBuilder };
+  response: { [StatusCode in HttpStatusCode]: WideResponseBuilder } & {
+    [key: number]: WideResponseBuilder;
+  };
 }

--- a/src/counterfact-types/wide-response-builder.ts
+++ b/src/counterfact-types/wide-response-builder.ts
@@ -1,3 +1,4 @@
+import type { COUNTERFACT_RESPONSE } from "./counterfact-response.js";
 import type { CookieOptions } from "./cookie-options.js";
 import type { MaybePromise } from "./maybe-promise.js";
 
@@ -20,7 +21,7 @@ export interface WideResponseBuilder {
   html: (body: unknown) => WideResponseBuilder;
   json: (body: unknown) => WideResponseBuilder;
   match: (contentType: string, body: unknown) => WideResponseBuilder;
-  random: () => MaybePromise<WideResponseBuilder>;
+  random: () => MaybePromise<COUNTERFACT_RESPONSE>;
   text: (body: unknown) => WideResponseBuilder;
   xml: (body: unknown) => WideResponseBuilder;
   stream: (body: AsyncIterable<unknown>) => WideResponseBuilder;

--- a/src/counterfact-types/wide-response-builder.ts
+++ b/src/counterfact-types/wide-response-builder.ts
@@ -8,7 +8,7 @@ import type { MaybePromise } from "./maybe-promise.js";
  * `GenericResponseBuilder`, this interface accepts `unknown` for all body
  * arguments and does not enforce content-type constraints.
  */
-export interface WideResponseBuilder {
+export type WideResponseBuilder = COUNTERFACT_RESPONSE & {
   binary: (body: Uint8Array | string) => WideResponseBuilder;
   empty: () => WideResponseBuilder;
   example: (name: string) => WideResponseBuilder;
@@ -17,12 +17,12 @@ export interface WideResponseBuilder {
     value: string,
     options?: CookieOptions,
   ) => WideResponseBuilder;
-  header: (body: unknown) => WideResponseBuilder;
+  header: (name: string, value: string) => WideResponseBuilder;
   html: (body: unknown) => WideResponseBuilder;
   json: (body: unknown) => WideResponseBuilder;
   match: (contentType: string, body: unknown) => WideResponseBuilder;
-  random: () => MaybePromise<COUNTERFACT_RESPONSE>;
+  random: () => MaybePromise<WideResponseBuilder>;
   text: (body: unknown) => WideResponseBuilder;
   xml: (body: unknown) => WideResponseBuilder;
-  stream: (body: AsyncIterable<unknown>) => WideResponseBuilder;
-}
+  stream: (body: AsyncIterable<unknown>) => COUNTERFACT_RESPONSE;
+};

--- a/test/server/types.test-d.ts
+++ b/test/server/types.test-d.ts
@@ -116,19 +116,37 @@ expectAssignable<MaybePromise<string>>(Promise.resolve("hello"));
 expectNotAssignable<MaybePromise<string>>(42);
 expectNotAssignable<MaybePromise<string>>(Promise.resolve(42));
 
-// Wide routes can return completed and fluent responses for a versioned request.
+// Generated routes retain schema validation, while versioned wide routes accept
+// any response body.
+type SchemaCheckedJsonResponse = {
+  content: { "application/json": { schema: { id: number } } };
+  headers: {};
+  requiredHeaders: never;
+  examples: {};
+};
+
+declare const generatedResponse: ResponseBuilderFactory<{
+  200: SchemaCheckedJsonResponse;
+}>;
+
+expectError(generatedResponse[200].json("invalid json per schema"));
+expectAssignable<COUNTERFACT_RESPONSE>(generatedResponse[200].json({ id: 1 }));
+
 type WideRoute = ($: {
   x: WideOperationArgument;
 }) => MaybePromise<COUNTERFACT_RESPONSE>;
 
 const wideRandomRoute: WideRoute = ($) => $.x.response[200].random();
 const wideJsonRoute: WideRoute = ($) => $.x.response[200].json({ ok: true });
+const wideInvalidJsonRoute: WideRoute = ($) =>
+  $.x.response[200].json("invalid json per schema");
 const wideChainedRoute: WideRoute = ($) =>
   $.x.response[200].header("x-request-id", "request-123").json({ ok: true });
 declare const stream: AsyncIterable<unknown>;
 const wideStreamRoute: WideRoute = ($) => $.x.response[200].stream(stream);
 expectAssignable<WideRoute>(wideRandomRoute);
 expectAssignable<WideRoute>(wideJsonRoute);
+expectAssignable<WideRoute>(wideInvalidJsonRoute);
 expectAssignable<WideRoute>(wideChainedRoute);
 expectAssignable<WideRoute>(wideStreamRoute);
 

--- a/test/server/types.test-d.ts
+++ b/test/server/types.test-d.ts
@@ -116,13 +116,21 @@ expectAssignable<MaybePromise<string>>(Promise.resolve("hello"));
 expectNotAssignable<MaybePromise<string>>(42);
 expectNotAssignable<MaybePromise<string>>(Promise.resolve(42));
 
-// Wide routes can return a random response for a versioned request.
+// Wide routes can return completed and fluent responses for a versioned request.
 type WideRoute = ($: {
   x: WideOperationArgument;
 }) => MaybePromise<COUNTERFACT_RESPONSE>;
 
 const wideRandomRoute: WideRoute = ($) => $.x.response[200].random();
+const wideJsonRoute: WideRoute = ($) => $.x.response[200].json({ ok: true });
+const wideChainedRoute: WideRoute = ($) =>
+  $.x.response[200].header("x-request-id", "request-123").json({ ok: true });
+declare const stream: AsyncIterable<unknown>;
+const wideStreamRoute: WideRoute = ($) => $.x.response[200].stream(stream);
 expectAssignable<WideRoute>(wideRandomRoute);
+expectAssignable<WideRoute>(wideJsonRoute);
+expectAssignable<WideRoute>(wideChainedRoute);
+expectAssignable<WideRoute>(wideStreamRoute);
 
 // OmitValueWhenNever: keys whose value is `never` are removed from the type
 expectType<OmitValueWhenNever<{ a: string; b: never }>>({ a: "hello" });

--- a/test/server/types.test-d.ts
+++ b/test/server/types.test-d.ts
@@ -17,6 +17,7 @@ import type {
   OmitValueWhenNever,
   OpenApiResponse,
   ResponseBuilderFactory,
+  WideOperationArgument,
 } from "../../src/counterfact-types/index.ts";
 
 // test exact match
@@ -114,6 +115,14 @@ expectAssignable<MaybePromise<string>>("hello");
 expectAssignable<MaybePromise<string>>(Promise.resolve("hello"));
 expectNotAssignable<MaybePromise<string>>(42);
 expectNotAssignable<MaybePromise<string>>(Promise.resolve(42));
+
+// Wide routes can return a random response for a versioned request.
+type WideRoute = ($: {
+  x: WideOperationArgument;
+}) => MaybePromise<COUNTERFACT_RESPONSE>;
+
+const wideRandomRoute: WideRoute = ($) => $.x.response[200].random();
+expectAssignable<WideRoute>(wideRandomRoute);
 
 // OmitValueWhenNever: keys whose value is `never` are removed from the type
 expectType<OmitValueWhenNever<{ a: string; b: never }>>({ a: "hello" });


### PR DESCRIPTION
## Summary

Make wide-route response helpers valid handler return values, including `.json()`, chained helpers, `.random()`, and `.stream()`.

## Root cause

`WideResponseBuilder` was not assignable to `COUNTERFACT_RESPONSE`, even though its fluent helpers return runtime response objects that a route handler can return directly. This caused valid wide-route implementations such as `$.x.response[200].json(...)` to fail type checking.

## Changes

- Make `WideResponseBuilder` a completed Counterfact response while preserving its fluent API.
- Ensure standard HTTP status codes such as `200` are available without an `undefined` result under strict indexed access.
- Type `.random()` as returning a fluent wide response.
- Type `.stream()` as a terminal response.
- Correct `.header()` to accept a header name and value.
- Add regression type tests for random, JSON, chained-header JSON, and stream responses.
- Add a patch changeset.

## Validation

- TypeScript compilation
- `tsd` type tests
- ESLint
- Unit tests: 873 passed
- Black-box tests: 13 passed