### PR TITLE
fix(runtime): reload atomic store replacements

### DIFF
--- a/.changeset/calm-stores-reload.md
+++ b/.changeset/calm-stores-reload.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Reload the application store reliably when editors replace its source file atomically.

--- a/packages/runtime/src/server/store-loader.ts
+++ b/packages/runtime/src/server/store-loader.ts
@@ -1,4 +1,5 @@
-import { access } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 
 import { type FSWatcher, watch } from "chokidar";
@@ -9,6 +10,8 @@ import { determineModuleKind } from "./determine-module-kind.js";
 import { uncachedImport } from "./uncached-import.js";
 
 const { uncachedRequire } = await import("./uncached-require.cjs");
+
+const RECONCILE_DELAY_MS = 60;
 
 type Store = object;
 
@@ -36,9 +39,13 @@ export class StoreLoader {
 
   private sourcePresent = false;
 
+  private sourceRevision: string | undefined;
+
   private watcher: FSWatcher | undefined;
 
   private eventQueue: Promise<void> = Promise.resolve();
+
+  private reconcileTimer: ReturnType<typeof setTimeout> | undefined;
 
   public constructor(basePath: string, callbacks: StoreLoaderCallbacks = {}) {
     this.sourcePath = path.resolve(basePath, "_.store.ts");
@@ -51,7 +58,10 @@ export class StoreLoader {
   public async load(): Promise<Store | undefined> {
     if (this.initialized) return this.store;
 
-    if (!(await this.fileExists())) {
+    const revision = await this.readSourceRevision();
+    this.sourceRevision = revision;
+
+    if (revision === undefined) {
       this.sourcePresent = false;
       this.initialized = true;
       return undefined;
@@ -75,11 +85,7 @@ export class StoreLoader {
       ...CHOKIDAR_OPTIONS,
       awaitWriteFinish: { pollInterval: 10, stabilityThreshold: 50 },
       depth: 0,
-    }).on("all", (eventName: string, filePath: string) => {
-      if (path.resolve(filePath) !== this.sourcePath) {
-        return;
-      }
-
+    }).on("all", (eventName: string) => {
       if (
         eventName !== "add" &&
         eventName !== "change" &&
@@ -88,9 +94,11 @@ export class StoreLoader {
         return;
       }
 
-      this.enqueue(async () => {
-        await this.handleWatchEvent(eventName);
-      });
+      // Editors commonly replace a file by writing a sibling temporary file
+      // and renaming it over the original. Coalesce every shallow directory
+      // transition, then compare the exact source contents so unrelated files
+      // cannot trigger a store reload.
+      this.scheduleReconcile();
     });
 
     await waitForEvent(this.watcher, "ready");
@@ -98,7 +106,7 @@ export class StoreLoader {
     // Reconcile after the initial scan because ignoreInitial deliberately
     // suppresses add events. This also closes the load-to-watch race.
     this.enqueue(async () => {
-      await this.reconcileAfterReady();
+      await this.reconcileSource();
     });
     await this.eventQueue;
   }
@@ -108,7 +116,31 @@ export class StoreLoader {
     const watcher = this.watcher;
     this.watcher = undefined;
     await watcher?.close();
+    this.flushScheduledReconcile();
     await this.eventQueue;
+  }
+
+  private scheduleReconcile(): void {
+    if (this.reconcileTimer !== undefined) {
+      clearTimeout(this.reconcileTimer);
+    }
+
+    this.reconcileTimer = setTimeout(() => {
+      this.reconcileTimer = undefined;
+      this.enqueue(async () => {
+        await this.reconcileSource();
+      });
+    }, RECONCILE_DELAY_MS);
+  }
+
+  private flushScheduledReconcile(): void {
+    if (this.reconcileTimer === undefined) return;
+
+    clearTimeout(this.reconcileTimer);
+    this.reconcileTimer = undefined;
+    this.enqueue(async () => {
+      await this.reconcileSource();
+    });
   }
 
   private enqueue(operation: () => Promise<void>): void {
@@ -119,32 +151,19 @@ export class StoreLoader {
       });
   }
 
-  private async handleWatchEvent(
-    eventName: "add" | "change" | "unlink",
-  ): Promise<void> {
-    if (eventName === "unlink") {
+  private async reconcileSource(): Promise<void> {
+    const revision = await this.readSourceRevision();
+
+    if (this.initialized && revision === this.sourceRevision) return;
+
+    this.sourceRevision = revision;
+
+    if (revision === undefined) {
       await this.updateSourcePresence(false);
       this.initialized = true;
       if (this.store !== undefined) {
         throw new Error("the store source was deleted");
       }
-      return;
-    }
-
-    await this.updateSourcePresence(true);
-    const candidate = await this.importCandidate();
-    await this.applyCandidate(candidate);
-    this.initialized = true;
-  }
-
-  private async reconcileAfterReady(): Promise<void> {
-    const present = await this.fileExists();
-
-    if (this.initialized && present === this.sourcePresent) return;
-
-    if (!present) {
-      await this.updateSourcePresence(false);
-      this.initialized = true;
       return;
     }
 
@@ -236,12 +255,16 @@ export class StoreLoader {
     );
   }
 
-  private async fileExists(): Promise<boolean> {
+  private async readSourceRevision(): Promise<string | undefined> {
     try {
-      await access(this.sourcePath);
-      return true;
-    } catch {
-      return false;
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- sourcePath is the constructor-resolved conventional store path.
+      const source = await readFile(this.sourcePath);
+      return createHash("sha256").update(source).digest("hex");
+    } catch (error: unknown) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        return undefined;
+      }
+      throw error;
     }
   }
 }

--- a/packages/runtime/test/server/store-loader.test.ts
+++ b/packages/runtime/test/server/store-loader.test.ts
@@ -105,6 +105,67 @@ describe("StoreLoader", () => {
     });
   });
 
+  it("reloads an atomic replacement without reporting the temporary gap as deletion", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "_.store.ts",
+        'export class Store { value = "initial"; method() { return "old" } }',
+      );
+      const onStoreChange = jest.fn();
+      const stderr = jest.spyOn(process.stderr, "write").mockReturnValue(true);
+      const loader = new StoreLoader($.path("."), { onStoreChange });
+      const store = (await loader.load()) as {
+        method(): string;
+        value: string;
+      };
+      await loader.watch();
+
+      try {
+        const changed = eventTargetForCallback(onStoreChange);
+        jest.resetModules();
+        await $.add(
+          "_.store.ts.next",
+          'export class Store { value = "replacement"; added = true; method() { return "new" } }',
+        );
+        const replacement = await $.read("_.store.ts.next");
+        await $.remove("_.store.ts");
+        await $.add("_.store.ts", replacement);
+        await $.remove("_.store.ts.next");
+        await changed;
+
+        expect(loader.store).toBe(store);
+        expect(store).toMatchObject({ added: true, value: "initial" });
+        expect(store.method()).toBe("new");
+        expect(stderr).not.toHaveBeenCalledWith(
+          expect.stringContaining("deleted"),
+        );
+      } finally {
+        await loader.stopWatching();
+        stderr.mockRestore();
+      }
+    });
+  });
+
+  it("ignores changes to unrelated sibling files", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("_.store.ts", "export class Store { value = 1 }");
+      const onStoreChange = jest.fn();
+      const loader = new StoreLoader($.path("."), { onStoreChange });
+
+      await loader.load();
+      await loader.watch();
+
+      try {
+        await $.add("README.md", "unrelated");
+        await new Promise((resolve) => setTimeout(resolve, 500));
+
+        expect(onStoreChange).not.toHaveBeenCalled();
+      } finally {
+        await loader.stopWatching();
+      }
+    });
+  });
+
   it("retains the last good store and reports broken reloads and deletion", async () => {
     await usingTemporaryFiles(async ($) => {
       await $.add(


### PR DESCRIPTION
## Summary

- make StoreLoader resilient to editor-style atomic replacements of `_.store.ts`
- coalesce shallow directory events, then reload only when the store source content changes
- preserve the live store object and last-good state across replacements and broken reloads
- supersedes #2292 with an implementation based on the monorepo runtime package

## Original Prompt

Make StoreLoader watch reliably on Windows and when editors save by replacing the store file.

## Manual acceptance tests

- [ ] Start a project with a stateful `_.store.ts`, mutate its live state, then save the file normally; confirm methods update without resetting state.
- [ ] Save `_.store.ts` using an editor that writes a temporary sibling and renames it over the original; confirm the store reloads without a transient deletion error.
- [ ] Change an unrelated file in the same directory; confirm no store reload occurs.
- [ ] Introduce a syntax error, then repair it; confirm the last good store remains active and the repaired source reloads.
- [ ] Repeat the replacement workflow on Windows; confirm watching remains reliable without forcing polling on other platforms.

## Tasks

- [x] Reconcile directory watcher events against the exact store source contents.
- [x] Serialize and flush debounced reconciliation during watcher shutdown.
- [x] Add regression coverage for temporary-file replacement and unrelated sibling changes.
- [x] Add a runtime patch changeset.

## Repository learning check

- [x] StoreLoader remains owned by `@counterfact/runtime`; no facade or REPL boundary changed.
- [x] The shared chokidar configuration still enables polling only on Windows.
- [x] Runtime lint, type build, focused StoreLoader tests, and the full runtime test directory pass.

## Verification

- `./node_modules/.bin/eslint packages/runtime/src/server/store-loader.ts packages/runtime/test/server/store-loader.test.ts`
- `./node_modules/.bin/tsc --build packages/types/tsconfig.json packages/openapi/tsconfig.json packages/runtime/tsconfig.json --force --pretty false`
- `CHOKIDAR_USEPOLLING=true node --experimental-vm-modules ./node_modules/jest-cli/bin/jest.js --config jest.config.js packages/runtime/test/server/store-loader.test.ts --runInBand --forceExit --coverage=false`
- `CHOKIDAR_USEPOLLING=true node --experimental-vm-modules ./node_modules/jest-cli/bin/jest.js --config jest.config.js packages/runtime/test --runInBand --forceExit --coverage=false`
- `git diff --check`

The polling override in the verification commands avoids the current macOS sandbox's file-descriptor limit; the production watcher configuration is unchanged and remains Windows-only.
