### PR TITLE
chore: repair monorepo release preparation

### DIFF
--- a/.changeset/renovate-102ed22.md
+++ b/.changeset/renovate-102ed22.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `eslint-plugin-jest-dom` to `5.10.1`.

--- a/.changeset/renovate-115e22e.md
+++ b/.changeset/renovate-115e22e.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `recast` to `0.24.0`.

--- a/.changeset/renovate-3da23f7.md
+++ b/.changeset/renovate-3da23f7.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `eslint-plugin-jest-dom` to `5.9.0`.

--- a/.changeset/renovate-5769719.md
+++ b/.changeset/renovate-5769719.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `eslint` to `10.8.1`.

--- a/.changeset/renovate-584b0ca.md
+++ b/.changeset/renovate-584b0ca.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `astro` to `7.2.1`.

--- a/.changeset/renovate-9e1c651.md
+++ b/.changeset/renovate-9e1c651.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `eslint-plugin-n` to `18.3.0`.

--- a/.changeset/renovate-c570798.md
+++ b/.changeset/renovate-c570798.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `astro` to `7.2.0`.

--- a/.changeset/renovate-c85f87a.md
+++ b/.changeset/renovate-c85f87a.md
@@ -1,6 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `@typescript-eslint/eslint-plugin` to `8.67.0`.
-Updated dependency `@typescript-eslint/parser` to `8.67.0`.

--- a/.changeset/renovate-c8d4da6.md
+++ b/.changeset/renovate-c8d4da6.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `tsx` to `4.23.4`.

--- a/.changeset/renovate-c9156a6.md
+++ b/.changeset/renovate-c9156a6.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `@swc/core` to `1.16.0`.

--- a/.changeset/renovate-d5e30ef.md
+++ b/.changeset/renovate-d5e30ef.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `eslint-plugin-jest` to `29.16.1`.

--- a/.changeset/renovate-d6fb694.md
+++ b/.changeset/renovate-d6fb694.md
@@ -1,5 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `prettier` to `3.9.0`.

--- a/.changeset/renovate-e302cef.md
+++ b/.changeset/renovate-e302cef.md
@@ -1,6 +1,0 @@
----
-'counterfact': patch
----
-
-Updated dependency `@typescript-eslint/eslint-plugin` to `8.66.0`.
-Updated dependency `@typescript-eslint/parser` to `8.66.0`.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Create or update the version pull request
         id: changesets
-        uses: changesets/action@v2.1.0
+        uses: changesets/action@v1.9.0
         with:
           version: yarn changeset version
         env:
@@ -77,7 +77,7 @@ jobs:
       - name: Build verified release artifacts
         run: yarn build
       - name: Publish merged versions
-        uses: changesets/action@v2.1.0
+        uses: changesets/action@v1.9.0
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
## Summary

- restore compatibility between `changesets/action` and the repository's installed Changesets CLI
- keep the established `version` and `publish` workflow inputs by pinning the compatible official action release
- remove 13 obsolete release notes for root-only tooling, the private site, absent dependencies, and a superseded intermediate update
- allow the canonical `changeset-release/main` branch and stale #2282 to be rebuilt from the monorepo instead of restoring the former root-package layout

## Original Prompt

Regenerate the stale version-packages pull request under the new monorepo structure.

## Manual acceptance tests

- [ ] Merge this prerequisite and confirm the next Release prepare job passes the Changesets action step.
- [ ] Confirm #2282 is rebuilt from current `main` and changes only package-local manifests, changelogs, internal dependency pins, and consumed changesets.
- [ ] Confirm the version plan bumps runtime and OpenAPI directly, generator and REPL through exact internal dependencies, and `counterfact` to 2.16.2.
- [ ] Confirm `@counterfact/client` and `@counterfact/types` remain at their initial 0.1.0 versions.
- [ ] Keep #2282 unmerged until #2315, #2316, and #2317 have merged and the version branch includes their changesets.

## Tasks

- [x] Pin both release jobs to `changesets/action@v1.9.0`, which supports CLI 2.31.1 and the existing inputs.
- [x] Remove stale root-tooling/private-site changesets that no longer belong to a published package.
- [x] Preserve pre-extraction release notes on the existing `counterfact` 2.x line.
- [x] Rehearse version generation in a disposable worktree without committing version files.
- [x] Avoid all npm authentication and publication.

## Repository learning check

- [x] The private root remains orchestration-only and is never versioned.
- [x] Scoped packages retain independent Changesets ownership and exact internal dependency propagation.
- [x] The six scoped packages remain available for the separately approved initial 0.1.0 registry bootstrap documented in `docs/development/release-bootstrap.md`.
- [x] Prepare and publish remain separate; publication still requires manual dispatch and environment approval.

## Verification

- parsed `.github/workflows/release.yaml` with `js-yaml`
- verified the official `changesets/action@v1.9.0` contract supports Node 24, CLI v2, `version`, `publish`, and `hasChangesets`
- `node scripts/check-package-boundaries.mjs`
- `./node_modules/.bin/changeset status`
- disposable `./node_modules/.bin/changeset version` rehearsal with manifest/changelog inspection
- `git diff --check`

No package was versioned or published by this branch. After it merges, Changesets may prepare/update #2282 automatically; that PR remains merge-last.
