### PR TITLE
Only run black box tests on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,18 +73,18 @@ jobs:
         if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         run: yarn eslint -f github-annotations .
       - name: TypeScript
-        if: steps.docs-only.outputs.docs_only != 'true'
+        if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         run: yarn typecheck
       - name: Packed Consumer Test
-        if: steps.docs-only.outputs.docs_only != 'true'
+        if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         timeout-minutes: 5
         run: yarn test:packed-consumer
       - name: Exact Package Closure Tests
-        if: steps.docs-only.outputs.docs_only != 'true'
+        if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         timeout-minutes: 15
         run: yarn test:package-closures
       - name: Unit Tests
-        if: steps.docs-only.outputs.docs_only != 'true'
+        if: steps.docs-only.outputs.docs_only != 'true' && matrix.os != 'windows-latest'
         timeout-minutes: 2
         run: yarn test --runInBand --forceExit --verbose --no-watchman
       - name: Set up Python


### PR DESCRIPTION
CI takes a long time to run on Windows. Any Windows-specific failures should be caught by the black box tests, so skip all of the other tests. 