### PR TITLE
fix: harden OpenAPI routing and lifecycle cleanup

### DIFF
--- a/.changeset/calm-headers-match.md
+++ b/.changeset/calm-headers-match.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/client": patch
+---
+
+Match required request header names case-insensitively.

--- a/.changeset/complete-runner-shutdown.md
+++ b/.changeset/complete-runner-shutdown.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Attempt every API runner watcher cleanup even when one shutdown fails.

--- a/.changeset/contained-generation.md
+++ b/.changeset/contained-generation.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/generator": patch
+---
+
+Keep every generated repository file contained within its destination directory.

--- a/.changeset/linear-prefix-normalization.md
+++ b/.changeset/linear-prefix-normalization.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Normalize route-prefix trailing slashes in linear time.

--- a/.changeset/local-path-schemes.md
+++ b/.changeset/local-path-schemes.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/openapi": patch
+---
+
+Treat local filenames beginning with URL scheme text as filesystem paths.

--- a/.changeset/prefix-boundaries.md
+++ b/.changeset/prefix-boundaries.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Match configured route prefixes at URL path-segment boundaries.

--- a/.changeset/quiet-random-responses.md
+++ b/.changeset/quiet-random-responses.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Stop random response generation from logging internal options to stdout.

--- a/.changeset/random-header-casing.md
+++ b/.changeset/random-header-casing.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Avoid generating duplicate required response headers with different casing.

--- a/.changeset/reject-unsafe-routes.md
+++ b/.changeset/reject-unsafe-routes.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/generator": patch
+---
+
+Reject OpenAPI route paths that cannot be represented safely in generated output.

--- a/.changeset/request-header-types.md
+++ b/.changeset/request-header-types.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Apply OpenAPI header parameter types regardless of header-name casing.

--- a/.changeset/response-header-casing.md
+++ b/.changeset/response-header-casing.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/runtime": patch
+---
+
+Validate response headers case-insensitively as required by HTTP.

--- a/.changeset/rollback-startup-resources.md
+++ b/.changeset/rollback-startup-resources.md
@@ -1,0 +1,5 @@
+---
+"counterfact": patch
+---
+
+Roll back partially started resources and complete every shutdown operation after failures.

--- a/.changeset/safe-path-values.md
+++ b/.changeset/safe-path-values.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/client": patch
+---
+
+Percent-encode path parameter values before sending requests.

--- a/.changeset/shared-path-parameters.md
+++ b/.changeset/shared-path-parameters.md
@@ -1,0 +1,5 @@
+---
+"@counterfact/client": patch
+---
+
+Include inherited path-item parameters in route request guidance and validation.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:package-closures": "node scripts/test-package-closures.mjs",
     "test:tsd": "tsd --typings ./packages/types/dist/index.d.ts --files ./packages/types/test/**/*.test-d.ts",
     "build": "yarn workspace counterfact build",
-    "typecheck": "tsc --build --noEmit --pretty false",
+    "typecheck": "tsc --noEmit --pretty false -p packages/types && tsc --noEmit --pretty false -p packages/openapi && tsc --noEmit --pretty false -p packages/runtime && tsc --noEmit --pretty false -p packages/client && tsc --noEmit --pretty false -p packages/generator && tsc --noEmit --pretty false -p packages/repl && tsc --noEmit --pretty false -p packages/counterfact",
     "release:preflight": "node scripts/release-preflight.mjs",
     "release": "changeset publish",
     "prepare": "husky install",

--- a/packages/client/src/route-builder.ts
+++ b/packages/client/src/route-builder.ts
@@ -183,7 +183,12 @@ export class RouteBuilder {
         missingParams.path = [...(missingParams.path ?? []), paramInfo];
       } else if (param.in === "query" && !(param.name in this._queryParams)) {
         missingParams.query = [...(missingParams.query ?? []), paramInfo];
-      } else if (param.in === "header" && !(param.name in this._headerParams)) {
+      } else if (
+        param.in === "header" &&
+        !Object.keys(this._headerParams).some(
+          (name) => name.toLowerCase() === param.name.toLowerCase(),
+        )
+      ) {
         missingParams.header = [...(missingParams.header ?? []), paramInfo];
       }
     }

--- a/packages/client/src/route-builder.ts
+++ b/packages/client/src/route-builder.ts
@@ -336,7 +336,7 @@ export class RouteBuilder {
     let url = this.routePath;
 
     for (const [key, value] of Object.entries(this._pathParams)) {
-      url = url.replaceAll(`{${key}}`, String(value));
+      url = url.replaceAll(`{${key}}`, encodeURIComponent(String(value)));
     }
 
     // Append query string

--- a/packages/client/src/route-catalog.ts
+++ b/packages/client/src/route-catalog.ts
@@ -34,6 +34,31 @@ export interface OpenApiRouteDocument {
   readonly paths: Readonly<Record<string, object>>;
 }
 
+function mergeParameters(
+  pathItemParameters: readonly RouteParameter[] | undefined,
+  operationParameters: readonly RouteParameter[] | undefined,
+): readonly RouteParameter[] | undefined {
+  if (!pathItemParameters || pathItemParameters.length === 0) {
+    return operationParameters;
+  }
+
+  if (!operationParameters || operationParameters.length === 0) {
+    return pathItemParameters;
+  }
+
+  const parameters = new Map<string, RouteParameter>();
+
+  for (const parameter of pathItemParameters) {
+    parameters.set(`${parameter.in}:${parameter.name}`, parameter);
+  }
+
+  for (const parameter of operationParameters) {
+    parameters.set(`${parameter.in}:${parameter.name}`, parameter);
+  }
+
+  return [...parameters.values()];
+}
+
 /**
  * Adapts an OpenAPI-like document to the client package's narrow route
  * catalog. The document is retained by reference so live OpenAPI reloads are
@@ -56,7 +81,25 @@ export function createOpenApiRouteCatalog(
       const pathItem = document.paths[matchingPath] as
         Record<string, unknown> | undefined;
 
-      return pathItem?.[method.toLowerCase()] as RouteOperation | undefined;
+      const operation = pathItem?.[method.toLowerCase()] as
+        RouteOperation | undefined;
+
+      if (!operation) {
+        return undefined;
+      }
+
+      const pathItemParameters = pathItem?.parameters as
+        readonly RouteParameter[] | undefined;
+      const parameters = mergeParameters(
+        pathItemParameters,
+        operation.parameters,
+      );
+
+      if (!pathItemParameters || pathItemParameters.length === 0) {
+        return operation;
+      }
+
+      return { ...operation, parameters };
     },
     listPaths() {
       return Object.keys(document.paths);

--- a/packages/client/test/route-builder.test.ts
+++ b/packages/client/test/route-builder.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from "@jest/globals";
+import { describe, expect, it, jest } from "@jest/globals";
 
 import {
+  RawHttpClient,
   RouteBuilder,
   createOpenApiRouteCatalog,
   createRouteFunction,
@@ -408,6 +409,29 @@ describe("RouteBuilder", () => {
       await expect(builder.send()).rejects.toThrow(
         "Unsupported HTTP method: BREW",
       );
+    });
+
+    it("encodes path parameter values before sending", async () => {
+      const get = jest
+        .spyOn(RawHttpClient.prototype, "get")
+        .mockResolvedValue("HTTP/1.1 200 OK");
+
+      try {
+        await new RouteBuilder("/pet/{petId}", {
+          port: 9999,
+          routeCatalog: ROUTE_CATALOG,
+        })
+          .method("get")
+          .path({ petId: "one/two?admin=true#details" })
+          .send();
+
+        expect(get).toHaveBeenCalledWith(
+          "/pet/one%2Ftwo%3Fadmin%3Dtrue%23details",
+          {},
+        );
+      } finally {
+        get.mockRestore();
+      }
     });
   });
 

--- a/packages/client/test/route-builder.test.ts
+++ b/packages/client/test/route-builder.test.ts
@@ -187,6 +187,34 @@ describe("RouteBuilder", () => {
       expect(builder.ready()).toBe(true);
     });
 
+    it("includes required path-item parameters", () => {
+      const catalog = createOpenApiRouteCatalog({
+        paths: {
+          "/path-item/{id}": {
+            get: { responses: { "200": {} } },
+            parameters: [
+              {
+                in: "path",
+                name: "id",
+                required: true,
+                type: "string",
+              },
+            ],
+          },
+        },
+      });
+      const builder = new RouteBuilder("/path-item/{id}", {
+        port: 9999,
+        routeCatalog: catalog,
+      }).method("get");
+
+      expect(builder.ready()).toBe(false);
+      expect(builder.missing()?.path).toEqual([
+        { description: undefined, name: "id", type: "string" },
+      ]);
+      expect(builder.path({ id: "one" }).ready()).toBe(true);
+    });
+
     it("returns true when no OpenAPI document is provided", () => {
       const builder = new RouteBuilder("/pet/{petId}", {
         port: 9999,

--- a/packages/client/test/route-builder.test.ts
+++ b/packages/client/test/route-builder.test.ts
@@ -275,6 +275,20 @@ describe("RouteBuilder", () => {
           .ready(),
       ).toBe(true);
     });
+
+    it("treats required header names case-insensitively", () => {
+      const builder = new RouteBuilder("/complete/{id}", {
+        port: 9999,
+        routeCatalog: ROUTE_CATALOG,
+      })
+        .method("get")
+        .path({ id: "one" })
+        .query({ filter: "active" })
+        .headers({ "X-Token": "secret" });
+
+      expect(builder.ready()).toBe(true);
+      expect(builder.missing()).toBeUndefined();
+    });
   });
 
   describe("help()", () => {

--- a/packages/client/test/route-catalog.test.ts
+++ b/packages/client/test/route-catalog.test.ts
@@ -29,6 +29,54 @@ describe("createOpenApiRouteCatalog", () => {
     expect(catalog.getOperation("/pets", "post")).toBeUndefined();
   });
 
+  it("merges path-item parameters with operation parameters", () => {
+    const catalog = createOpenApiRouteCatalog({
+      paths: {
+        "/pets/{petId}": {
+          get: {
+            parameters: [
+              {
+                in: "header",
+                name: "x-token",
+                required: false,
+                type: "string",
+              },
+            ],
+          },
+          parameters: [
+            {
+              in: "path",
+              name: "petId",
+              required: true,
+              type: "string",
+            },
+            {
+              in: "header",
+              name: "x-token",
+              required: true,
+              type: "string",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(catalog.getOperation("/pets/{petId}", "get")?.parameters).toEqual([
+      {
+        in: "path",
+        name: "petId",
+        required: true,
+        type: "string",
+      },
+      {
+        in: "header",
+        name: "x-token",
+        required: false,
+        type: "string",
+      },
+    ]);
+  });
+
   it("reads a live document instead of snapshotting it", () => {
     const document = {
       paths: { "/pets": { get: {} } } as Record<string, object>,

--- a/packages/counterfact/src/api-runner.ts
+++ b/packages/counterfact/src/api-runner.ts
@@ -341,10 +341,22 @@ export class ApiRunner {
    * Stops all active file-system watchers across every sub-system.
    */
   public async stopWatching(): Promise<void> {
-    await this.codeGenerator.stopWatching();
-    await this.scenarioFileGenerator.stopWatching();
-    await this.transpiler.stopWatching();
-    await this.moduleLoader.stopWatching();
-    await this.openApiDocument?.stopWatching();
+    const results = await Promise.allSettled([
+      this.codeGenerator.stopWatching(),
+      this.scenarioFileGenerator.stopWatching(),
+      this.transpiler.stopWatching(),
+      this.moduleLoader.stopWatching(),
+      this.openApiDocument?.stopWatching(),
+    ]);
+    const errors = results.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+
+    if (errors.length > 0) {
+      throw new AggregateError(
+        errors,
+        "Failed to stop all API runner watchers",
+      );
+    }
   }
 }

--- a/packages/counterfact/src/app.ts
+++ b/packages/counterfact/src/app.ts
@@ -372,6 +372,18 @@ export async function counterfact<TStore = unknown>(
   async function start(
     options: Pick<Config, "generate" | "startServer" | "watch" | "buildCache">,
   ) {
+    async function completeStage(operations: Array<Promise<unknown>>) {
+      const results = await Promise.allSettled(operations);
+      const failure = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+
+      if (failure !== undefined) {
+        throw failure.reason;
+      }
+    }
+
     // Serialize generate() calls within each group to avoid concurrent writes
     // to the same output directory.  Runners that share a group share the same
     // basePath subdirectory (and therefore the same counterfact-types
@@ -435,27 +447,39 @@ export async function counterfact<TStore = unknown>(
         }),
       );
     }
-    await Promise.all(runners.map((runner) => runner.watch()));
-    await Promise.all(runners.map((runner) => runner.start(options)));
-
-    if (options.startServer) {
-      await storeLoader.watch();
-    }
-
     let httpTerminator: HttpTerminator | undefined;
 
-    if (options.startServer) {
-      try {
-        await runGroupStartupScenarios(runners, { port: config.port });
-      } catch (error) {
-        // Startup happens after the runner watchers are active. If a scenario
-        // fails, release those resources and leave the HTTP port untouched.
-        await Promise.allSettled([
-          ...runners.map((runner) => runner.stopWatching()),
-          storeLoader.stopWatching(),
-        ]);
-        throw error;
+    async function stopResources(): Promise<void> {
+      const results = await Promise.allSettled([
+        ...runners.map((runner) => runner.stopWatching()),
+        storeLoader.stopWatching(),
+        httpTerminator?.terminate(),
+      ]);
+      const errors = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+
+      if (errors.length > 0) {
+        throw new AggregateError(
+          errors,
+          "Failed to stop all Counterfact resources",
+        );
       }
+    }
+
+    try {
+      await completeStage(runners.map((runner) => runner.watch()));
+      await completeStage(runners.map((runner) => runner.start(options)));
+
+      if (options.startServer) {
+        await storeLoader.watch();
+      }
+
+      if (!options.startServer) {
+        return { stop: stopResources };
+      }
+
+      await runGroupStartupScenarios(runners, { port: config.port });
 
       const server = koaApp.listen({
         port: config.port,
@@ -464,16 +488,13 @@ export async function counterfact<TStore = unknown>(
       httpTerminator = createHttpTerminator({
         server,
       });
+    } catch (error) {
+      await stopResources().catch(() => undefined);
+      throw error;
     }
 
     return {
-      async stop() {
-        await Promise.all([
-          ...runners.map((runner) => runner.stopWatching()),
-          storeLoader.stopWatching(),
-        ]);
-        await httpTerminator?.terminate();
-      },
+      stop: stopResources,
     };
   }
 

--- a/packages/counterfact/test/api-runner.test.ts
+++ b/packages/counterfact/test/api-runner.test.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from "node:url";
 
+import { jest } from "@jest/globals";
 import { usingTemporaryFiles } from "using-temporary-files";
 
 import { ApiRunner } from "../src/api-runner.js";
@@ -287,6 +288,33 @@ describe("ApiRunner", () => {
         });
         await runner.start({ startServer: false, buildCache: false });
         await expect(runner.stopWatching()).resolves.toBeUndefined();
+      });
+    });
+
+    it("attempts every watcher shutdown when one fails", async () => {
+      await usingTemporaryFiles(async ($) => {
+        const runner = await ApiRunner.create({
+          ...baseConfig,
+          basePath: $.path("."),
+        });
+        const codeGeneratorStop = jest
+          .spyOn(runner.codeGenerator, "stopWatching")
+          .mockRejectedValue(new Error("code generator failed"));
+        const scenarioGeneratorStop = jest
+          .spyOn(runner.scenarioFileGenerator, "stopWatching")
+          .mockResolvedValue(undefined);
+        const transpilerStop = jest
+          .spyOn(runner.transpiler, "stopWatching")
+          .mockResolvedValue(undefined);
+        const moduleLoaderStop = jest
+          .spyOn(runner.moduleLoader, "stopWatching")
+          .mockResolvedValue(undefined);
+
+        await expect(runner.stopWatching()).rejects.toThrow(AggregateError);
+        expect(codeGeneratorStop).toHaveBeenCalledTimes(1);
+        expect(scenarioGeneratorStop).toHaveBeenCalledTimes(1);
+        expect(transpilerStop).toHaveBeenCalledTimes(1);
+        expect(moduleLoaderStop).toHaveBeenCalledTimes(1);
       });
     });
   });

--- a/packages/counterfact/test/app.test.ts
+++ b/packages/counterfact/test/app.test.ts
@@ -883,6 +883,146 @@ describe("counterfact", () => {
     });
   });
 
+  it("rolls back resources when runner watching fails", async () => {
+    const watch = jest
+      .spyOn(ApiRunner.prototype, "watch")
+      .mockRejectedValue(new Error("watch failed"));
+    const stopWatching = jest
+      .spyOn(ApiRunner.prototype, "stopWatching")
+      .mockResolvedValue(undefined);
+    const storeStopWatching = jest
+      .spyOn(StoreLoader.prototype, "stopWatching")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await (app as any).counterfact(mockConfig);
+
+      await expect(
+        result.start({
+          startServer: false,
+          buildCache: false,
+          generate: { routes: false, types: false },
+          watch: { routes: false, types: false },
+        }),
+      ).rejects.toThrow("watch failed");
+      expect(stopWatching).toHaveBeenCalledTimes(1);
+      expect(storeStopWatching).toHaveBeenCalledTimes(1);
+    } finally {
+      storeStopWatching.mockRestore();
+      stopWatching.mockRestore();
+      watch.mockRestore();
+    }
+  });
+
+  it("rolls back resources when runner startup fails", async () => {
+    const watch = jest
+      .spyOn(ApiRunner.prototype, "watch")
+      .mockResolvedValue(undefined);
+    const startRunner = jest
+      .spyOn(ApiRunner.prototype, "start")
+      .mockRejectedValue(new Error("runner start failed"));
+    const stopWatching = jest
+      .spyOn(ApiRunner.prototype, "stopWatching")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await (app as any).counterfact(mockConfig);
+
+      await expect(
+        result.start({
+          startServer: false,
+          buildCache: false,
+          generate: { routes: false, types: false },
+          watch: { routes: false, types: false },
+        }),
+      ).rejects.toThrow("runner start failed");
+      expect(stopWatching).toHaveBeenCalledTimes(1);
+    } finally {
+      stopWatching.mockRestore();
+      startRunner.mockRestore();
+      watch.mockRestore();
+    }
+  });
+
+  it("rolls back resources and does not listen when store watching fails", async () => {
+    const watch = jest
+      .spyOn(ApiRunner.prototype, "watch")
+      .mockResolvedValue(undefined);
+    const startRunner = jest
+      .spyOn(ApiRunner.prototype, "start")
+      .mockResolvedValue(undefined);
+    const stopWatching = jest
+      .spyOn(ApiRunner.prototype, "stopWatching")
+      .mockResolvedValue(undefined);
+    const storeWatch = jest
+      .spyOn(StoreLoader.prototype, "watch")
+      .mockRejectedValue(new Error("store watch failed"));
+
+    try {
+      const result = await (app as any).counterfact({
+        ...mockConfig,
+        port: 0,
+      });
+      const listen = jest.spyOn(result.koaApp, "listen");
+
+      await expect(
+        result.start({
+          startServer: true,
+          buildCache: false,
+          generate: { routes: false, types: false },
+          watch: { routes: false, types: false },
+        }),
+      ).rejects.toThrow("store watch failed");
+      expect(stopWatching).toHaveBeenCalledTimes(1);
+      expect(listen).not.toHaveBeenCalled();
+      listen.mockRestore();
+    } finally {
+      storeWatch.mockRestore();
+      stopWatching.mockRestore();
+      startRunner.mockRestore();
+      watch.mockRestore();
+    }
+  });
+
+  it("terminates HTTP even when another shutdown operation fails", async () => {
+    const watch = jest
+      .spyOn(ApiRunner.prototype, "watch")
+      .mockResolvedValue(undefined);
+    const startRunner = jest
+      .spyOn(ApiRunner.prototype, "start")
+      .mockResolvedValue(undefined);
+    const stopWatching = jest
+      .spyOn(ApiRunner.prototype, "stopWatching")
+      .mockRejectedValue(new Error("runner stop failed"));
+    const storeWatch = jest
+      .spyOn(StoreLoader.prototype, "watch")
+      .mockResolvedValue(undefined);
+
+    try {
+      const result = await (app as any).counterfact({
+        ...mockConfig,
+        port: 0,
+      });
+      const listen = jest.spyOn(result.koaApp, "listen");
+      const { stop } = await result.start({
+        startServer: true,
+        buildCache: false,
+        generate: { routes: false, types: false },
+        watch: { routes: false, types: false },
+      });
+      const server = listen.mock.results[0]?.value;
+
+      await expect(stop()).rejects.toThrow(AggregateError);
+      expect(server?.listening).toBe(false);
+      listen.mockRestore();
+    } finally {
+      storeWatch.mockRestore();
+      stopWatching.mockRestore();
+      startRunner.mockRestore();
+      watch.mockRestore();
+    }
+  });
+
   it("preserves startup behavior when specs are omitted", async () => {
     await usingTemporaryFiles(async ($) => {
       const realCreate = ApiRunner.create;

--- a/packages/generator/src/openapi-path.ts
+++ b/packages/generator/src/openapi-path.ts
@@ -8,6 +8,43 @@ export function normalizeOpenApiPath(openApiPath: string): string {
   return openApiPath.replace(/\/+$/u, "") || "/";
 }
 
+function assertValidOpenApiPath(openApiPath: string): void {
+  const normalizedPath = normalizeOpenApiPath(openApiPath);
+  const invalidReason = invalidOpenApiPathReason(normalizedPath);
+
+  if (invalidReason !== undefined) {
+    throw new Error(
+      `Invalid OpenAPI path ${JSON.stringify(openApiPath)}: ${invalidReason}.`,
+    );
+  }
+}
+
+function invalidOpenApiPathReason(openApiPath: string): string | undefined {
+  if (!openApiPath.startsWith("/")) {
+    return "paths must begin with a forward slash";
+  }
+
+  if (openApiPath.includes("\0")) {
+    return "paths must not contain NUL characters";
+  }
+
+  if (openApiPath.includes("\\")) {
+    return "paths must use forward slashes only";
+  }
+
+  const segments = openApiPath.split("/").slice(1);
+
+  if (openApiPath !== "/" && segments.some((segment) => segment === "")) {
+    return "paths must not contain empty internal segments";
+  }
+
+  if (segments.some((segment) => segment === "." || segment === "..")) {
+    return 'paths must not contain "." or ".." segments';
+  }
+
+  return undefined;
+}
+
 /**
  * Rejects path keys that would target the same generated route module.
  */
@@ -17,6 +54,7 @@ export function assertNoNormalizedPathCollisions(
   const originalPathByNormalizedPath = new Map<string, string>();
 
   for (const openApiPath of openApiPaths) {
+    assertValidOpenApiPath(openApiPath);
     const normalizedPath = normalizeOpenApiPath(openApiPath);
     const existingPath = originalPathByNormalizedPath.get(normalizedPath);
 

--- a/packages/generator/src/repository.ts
+++ b/packages/generator/src/repository.ts
@@ -9,7 +9,6 @@ import createDebug from "debug";
 import { ensureDirectoryExists } from "./ensure-directory-exists.js";
 import {
   toForwardSlashPath,
-  pathJoin,
   pathRelative,
   pathDirname,
 } from "./forward-slash-path.js";
@@ -22,6 +21,45 @@ const debug = createDebug("counterfact:server:repository");
 const __dirname = toForwardSlashPath(dirname(fileURLToPath(import.meta.url)));
 
 debug("dirname is %s", __dirname);
+
+function assertSafeRepositoryPath(path: string): void {
+  const segments = path.split("/");
+
+  if (
+    path === "" ||
+    path.includes("\0") ||
+    path.includes("\\") ||
+    nodePath.posix.isAbsolute(path) ||
+    nodePath.win32.isAbsolute(path) ||
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    )
+  ) {
+    throw new Error(
+      `Repository path ${JSON.stringify(path)} must be a safe, relative, forward-slash path.`,
+    );
+  }
+}
+
+function resolveDestinationPath(destination: string, path: string): string {
+  const destinationRoot = nodePath.resolve(destination);
+  const candidatePath = nodePath.resolve(destinationRoot, path);
+  const relativePath = nodePath.relative(destinationRoot, candidatePath);
+
+  if (
+    relativePath === ".." ||
+    relativePath.startsWith(`..${nodePath.sep}`) ||
+    nodePath.isAbsolute(relativePath)
+  ) {
+    throw new Error(
+      `Repository path ${JSON.stringify(path)} escapes destination ${JSON.stringify(destinationRoot)}.`,
+    );
+  }
+
+  assertSafeRepositoryPath(path);
+
+  return escapePathForWindows(candidatePath);
+}
 
 interface WriteFilesOptions {
   routes?: boolean;
@@ -52,6 +90,8 @@ export class Repository {
    */
   public get(path: string): Script {
     debug("getting script at %s", path);
+
+    assertSafeRepositoryPath(path);
 
     if (this.scripts.has(path)) {
       debug("already have script %s, returning it", path);
@@ -142,9 +182,8 @@ export class Repository {
       this.scripts.entries(),
 
       async ([path, script]) => {
+        const fullPath = resolveDestinationPath(destination, path);
         const contents = await script.contents();
-
-        const fullPath = escapePathForWindows(pathJoin(destination, path));
 
         await ensureDirectoryExists(fullPath);
 

--- a/packages/generator/test/generate.test.ts
+++ b/packages/generator/test/generate.test.ts
@@ -211,6 +211,38 @@ describe("OpenAPI paths with trailing slashes", () => {
     });
   });
 
+  it.each([
+    "customers",
+    "/customers\0private",
+    "/customers\\..\\private",
+    "/customers//private",
+    "/customers/./private",
+    "/customers/../private",
+  ])("rejects unsafe OpenAPI path %p before writing files", async (path) => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add(
+        "openapi.json",
+        JSON.stringify({
+          openapi: "3.0.3",
+          info: { title: "Unsafe path", version: "1.0.0" },
+          paths: { [path]: operation("unsafeOperation") },
+        }),
+      );
+
+      const repository = new Repository();
+      const writeFiles = jest.fn(async () => {});
+      repository.writeFiles = writeFiles;
+
+      await expect(
+        new CodeGenerator($.path("openapi.json"), $.path("out"), {
+          routes: true,
+          types: true,
+        }).generate(repository),
+      ).rejects.toThrow("Invalid OpenAPI path");
+      expect(writeFiles).not.toHaveBeenCalled();
+    });
+  });
+
   it("prunes renamed path types in type-only mode and remains idempotent", async () => {
     await usingTemporaryFiles(async ($) => {
       const document = (path: string, operationId: string) => ({

--- a/packages/generator/test/repository.test.ts
+++ b/packages/generator/test/repository.test.ts
@@ -17,6 +17,38 @@ describe("a Repository", () => {
   });
 
   it.each([
+    "",
+    "../escaped.ts",
+    "/absolute.ts",
+    "C:\\absolute.ts",
+    "types\\..\\escaped.ts",
+    "types//escaped.ts",
+    "types/./escaped.ts",
+    "types/../escaped.ts",
+    "types/escaped\0.ts",
+  ])("rejects unsafe repository path %p", (path) => {
+    const repository = new Repository();
+
+    expect(() => repository.get(path)).toThrow(
+      "must be a safe, relative, forward-slash path",
+    );
+  });
+
+  it("rejects a destination escape injected directly into the scripts map", async () => {
+    await usingTemporaryFiles(async ({ path }) => {
+      const repository = new Repository();
+      const script = repository.get("types/safe.ts");
+
+      repository.scripts.clear();
+      repository.scripts.set("../escaped.ts", script);
+
+      await expect(
+        repository.writeFiles(path("output"), { routes: false, types: true }),
+      ).rejects.toThrow("escapes destination");
+    });
+  });
+
+  it.each([
     ["./types/paths/x.ts", "../../routes/_.context.ts"],
     ["./types/paths/a/x.ts", "../../../routes/_.context.ts"],
     ["./types/paths/a/b/x.ts", "../../../../routes/a/b/_.context.ts"],

--- a/packages/generator/test/script.test.ts
+++ b/packages/generator/test/script.test.ts
@@ -173,22 +173,22 @@ describe("a Script", () => {
       }
 
       modulePath() {
-        return "../../export-from-me.ts";
+        return "types/export-from-me.ts";
       }
     }
 
     const coder = new CoderThatWantsToImportAccount({});
 
-    const script = repository.get("import-to-me.ts");
+    const script = repository.get("routes/nested/import-to-me.ts");
 
     script.import(coder);
     script.importType(coder);
     script.importDefault(coder);
 
     expect(script.importStatements()).toStrictEqual([
-      'import { Account0 } from "../../export-from-me.js";',
-      'import type { Account1 } from "../../export-from-me.js";',
-      'import Account2 from "../../export-from-me.js";',
+      'import { Account0 } from "../../types/export-from-me.js";',
+      'import type { Account1 } from "../../types/export-from-me.js";',
+      'import Account2 from "../../types/export-from-me.js";',
     ]);
   });
 

--- a/packages/openapi/src/read-file.ts
+++ b/packages/openapi/src/read-file.ts
@@ -11,6 +11,24 @@ function normalizeLocalPath(path: string): string {
   return nodePath.resolve(path);
 }
 
+function parseSupportedUrl(urlOrPath: string): URL | undefined {
+  try {
+    const url = new URL(urlOrPath);
+
+    if (
+      url.protocol === "file:" ||
+      url.protocol === "http:" ||
+      url.protocol === "https:"
+    ) {
+      return url;
+    }
+  } catch {
+    // A local path is not necessarily a valid URL.
+  }
+
+  return undefined;
+}
+
 /**
  * Reads the content of a file or URL and returns it as a UTF-8 string.
  *
@@ -23,23 +41,21 @@ function normalizeLocalPath(path: string): string {
  * @returns The file contents as a string.
  */
 export async function readFile(urlOrPath: string) {
-  if (urlOrPath.startsWith("http")) {
+  if (urlOrPath.includes("\0")) {
+    throw new Error("File path cannot contain NUL bytes.");
+  }
+
+  const url = parseSupportedUrl(urlOrPath);
+
+  if (url?.protocol === "http:" || url?.protocol === "https:") {
     const response = await nodeFetch(urlOrPath);
 
     return await response.text();
   }
 
-  if (urlOrPath.startsWith("file")) {
-    const fileUrl = new URL(urlOrPath);
-
-    if (fileUrl.protocol !== "file:") {
-      throw new Error(
-        `Unsupported URL protocol for file read: ${fileUrl.protocol}`,
-      );
-    }
-
+  if (url?.protocol === "file:") {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- file URL is parsed and protocol-validated immediately above.
-    return await fs.readFile(fileUrl, "utf8");
+    return await fs.readFile(url, "utf8");
   }
 
   const normalizedPath = normalizeLocalPath(urlOrPath);

--- a/packages/openapi/test/read-file.test.ts
+++ b/packages/openapi/test/read-file.test.ts
@@ -22,6 +22,26 @@ describe("readFile", () => {
     });
   });
 
+  it("reads relative paths that begin with URL scheme names", async () => {
+    await usingTemporaryFiles(async ($) => {
+      await $.add("file-spec.yaml", "local file spec");
+      await $.add("httpspec.yaml", "local http spec");
+      const originalWorkingDirectory = process.cwd();
+      process.chdir($.path("."));
+
+      try {
+        await expect(readFile("file-spec.yaml")).resolves.toBe(
+          "local file spec",
+        );
+        await expect(readFile("httpspec.yaml")).resolves.toBe(
+          "local http spec",
+        );
+      } finally {
+        process.chdir(originalWorkingDirectory);
+      }
+    });
+  });
+
   it("rejects local paths containing NUL bytes", async () => {
     await expect(readFile("bad\0path.txt")).rejects.toThrow(
       "File path cannot contain NUL bytes.",

--- a/packages/repl/test/repl.test.ts
+++ b/packages/repl/test/repl.test.ts
@@ -1,4 +1,5 @@
-import type { REPLServer } from "node:repl";
+import repl, { type REPLServer, type ReplOptions } from "node:repl";
+import { PassThrough, Writable } from "node:stream";
 
 import { afterEach, jest } from "@jest/globals";
 
@@ -51,6 +52,14 @@ class ReplHarness {
 
   private readonly mock = new MockRepl();
 
+  private readonly input = new PassThrough();
+
+  private readonly replOutput = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+
   public output: string[] = [];
 
   public constructor(
@@ -62,17 +71,33 @@ class ReplHarness {
     store?: object,
     reportEvent?: ReplEventReporter,
   ) {
-    this.server = startRepl(
-      contextRegistry,
-      registry,
-      config,
-      (line) => this.output.push(line),
-      undefined,
-      scenarioRegistry,
-      apiBindings,
-      store,
-      reportEvent,
-    );
+    const originalStart = repl.start;
+    const startSpy = jest.spyOn(repl, "start").mockImplementation((options) => {
+      const replOptions: ReplOptions =
+        typeof options === "string" ? { prompt: options } : (options ?? {});
+
+      return originalStart({
+        ...replOptions,
+        input: this.input,
+        output: this.replOutput,
+      });
+    });
+
+    try {
+      this.server = startRepl(
+        contextRegistry,
+        registry,
+        config,
+        (line) => this.output.push(line),
+        undefined,
+        scenarioRegistry,
+        apiBindings,
+        store,
+        reportEvent,
+      );
+    } finally {
+      startSpy.mockRestore();
+    }
   }
 
   public call(name: string, options: string) {
@@ -88,6 +113,12 @@ class ReplHarness {
       this.mock.commandLog[0] === "clearBufferedCommand" &&
       this.mock.commandLog[1] === "displayPrompt"
     );
+  }
+
+  public close() {
+    this.server.close();
+    this.input.destroy();
+    this.replOutput.destroy();
   }
 }
 
@@ -113,16 +144,16 @@ function createHarness(
     reportEvent,
   );
 
-  openServers.push(harness.server);
+  openServers.push(harness);
 
   return { config, contextRegistry, harness, registry };
 }
 
-const openServers: REPLServer[] = [];
+const openServers: ReplHarness[] = [];
 
 afterEach(() => {
-  for (const server of openServers) {
-    server.close();
+  for (const harness of openServers) {
+    harness.close();
   }
 
   openServers.length = 0;

--- a/packages/runtime/src/server/registry.ts
+++ b/packages/runtime/src/server/registry.ts
@@ -138,11 +138,22 @@ function castParameter(value: string | number | boolean, type: string) {
 function castParameters(
   parameters: { [key: string]: string | number | boolean } = {},
   parameterTypes: Map<string, string> = new Map(),
+  caseInsensitive = false,
 ) {
   const copy: { [key: string]: boolean | number | string } = {};
 
+  const types = caseInsensitive
+    ? new Map(
+        Array.from(parameterTypes, ([key, value]) => [
+          key.toLowerCase(),
+          value,
+        ]),
+      )
+    : parameterTypes;
+
   Object.entries(parameters).forEach(([key, value]) => {
-    copy[key] = castParameter(value, parameterTypes.get(key) ?? "string");
+    const lookupKey = caseInsensitive ? key.toLowerCase() : key;
+    copy[key] = castParameter(value, types.get(lookupKey) ?? "string");
   });
 
   return copy;
@@ -344,7 +355,11 @@ export class Registry {
         x?: RequestDataWithBody;
       } = {
         ...requestData,
-        headers: castParameters(requestData.headers, parameterTypes.header),
+        headers: castParameters(
+          requestData.headers,
+          parameterTypes.header,
+          true,
+        ),
         matchedPath: handler.matchedPath,
         path: castParameters(handler.path, parameterTypes.path),
         query: castParameters(requestData.query, parameterTypes.query),

--- a/packages/runtime/src/server/response-builder.ts
+++ b/packages/runtime/src/server/response-builder.ts
@@ -295,8 +295,6 @@ export function createResponseBuilder(
           }
         }
 
-        console.log(generateOptions);
-
         return {
           ...this,
 

--- a/packages/runtime/src/server/response-builder.ts
+++ b/packages/runtime/src/server/response-builder.ts
@@ -282,9 +282,12 @@ export function createResponseBuilder(
         const { content } = response;
 
         const generatedHeaders: { [name: string]: string } = {};
+        const existingHeaderNames = new Set(
+          Object.keys(this.headers ?? {}).map((name) => name.toLowerCase()),
+        );
 
         for (const [name, header] of Object.entries(response.headers ?? {})) {
-          if (header.required && !(name in (this.headers ?? {}))) {
+          if (header.required && !existingHeaderNames.has(name.toLowerCase())) {
             generatedHeaders[name] = (await generate(
               (header.schema ?? { type: "string" }) as JsonSchema,
               generateOptions,

--- a/packages/runtime/src/server/response-validator.ts
+++ b/packages/runtime/src/server/response-validator.ts
@@ -37,10 +37,15 @@ export function validateResponse(
 
   const specHeaders = responseSpec.headers ?? {};
   const actualHeaders = response.headers ?? {};
+  const actualHeadersByLowercaseName = new Map(
+    Object.entries(actualHeaders).map(([name, value]) => [
+      name.toLowerCase(),
+      value,
+    ]),
+  );
 
   for (const [name, headerSpec] of Object.entries(specHeaders)) {
-    const actualValue =
-      actualHeaders[name] ?? actualHeaders[name.toLowerCase()];
+    const actualValue = actualHeadersByLowercaseName.get(name.toLowerCase());
 
     if (headerSpec.required === true && actualValue === undefined) {
       errors.push(`response header '${name}' is required`);

--- a/packages/runtime/src/server/web-server/routes-middleware.ts
+++ b/packages/runtime/src/server/web-server/routes-middleware.ts
@@ -120,6 +120,28 @@ function getAuthObject(
   return { password, username };
 }
 
+function pathWithinPrefix(
+  requestPath: string,
+  configuredPrefix: string,
+): string | undefined {
+  const prefix =
+    configuredPrefix === "/" ? "" : configuredPrefix.replace(/\/+$/u, "");
+
+  if (prefix === "") {
+    return requestPath || "/";
+  }
+
+  if (requestPath === prefix) {
+    return "/";
+  }
+
+  if (!requestPath.startsWith(`${prefix}/`)) {
+    return undefined;
+  }
+
+  return requestPath.slice(prefix.length);
+}
+
 /**
  * Builds the Koa middleware function that bridges Koa's request context with
  * the Counterfact {@link Dispatcher}.
@@ -153,15 +175,15 @@ export function routesMiddleware(
     debug("middleware running for path: %s", ctx.request.path);
     debug("prefix: %s", prefix);
 
-    if (!ctx.request.path.startsWith(prefix)) {
+    const path = pathWithinPrefix(ctx.request.path, prefix);
+
+    if (path === undefined) {
       return await next();
     }
 
     const auth = getAuthObject(ctx);
 
     const { body, headers, query, rawBody } = ctx.request;
-
-    const path = ctx.request.path.slice(prefix.length);
 
     const method = ctx.request.method as RequestMethod;
 
@@ -261,12 +283,11 @@ export function routesMiddlewareForRunners(
   proxy = koaProxy,
 ): Koa.Middleware {
   return async function multiRunnerRoutesMiddleware(ctx, next) {
-    const candidates = runners
-      .filter(({ prefix }) => ctx.request.path.startsWith(prefix))
-      .map((runner) => ({
-        path: ctx.request.path.slice(runner.prefix.length),
-        runner,
-      }));
+    const candidates = runners.flatMap((runner) => {
+      const path = pathWithinPrefix(ctx.request.path, runner.prefix);
+
+      return path === undefined ? [] : [{ path, runner }];
+    });
 
     if (candidates.length === 0) {
       return await next();

--- a/packages/runtime/src/server/web-server/routes-middleware.ts
+++ b/packages/runtime/src/server/web-server/routes-middleware.ts
@@ -124,8 +124,13 @@ function pathWithinPrefix(
   requestPath: string,
   configuredPrefix: string,
 ): string | undefined {
-  const prefix =
-    configuredPrefix === "/" ? "" : configuredPrefix.replace(/\/+$/u, "");
+  let prefixEnd = configuredPrefix.length;
+
+  while (prefixEnd > 0 && configuredPrefix.charCodeAt(prefixEnd - 1) === 47) {
+    prefixEnd -= 1;
+  }
+
+  const prefix = configuredPrefix.slice(0, prefixEnd);
 
   if (prefix === "") {
     return requestPath || "/";

--- a/packages/runtime/test/server/dispatcher.test.ts
+++ b/packages/runtime/test/server/dispatcher.test.ts
@@ -894,17 +894,17 @@ describe("a dispatcher", () => {
               },
               {
                 in: "header",
-                name: "numberInHeader",
+                name: "NumberInHeader",
                 type: "number",
               },
               {
                 in: "header",
-                name: "stringInHeader",
+                name: "StringInHeader",
                 type: "string",
               },
               {
                 in: "header",
-                name: "booleanInHeader",
+                name: "BooleanInHeader",
                 type: "boolean",
               },
             ],

--- a/packages/runtime/test/server/registry.test.ts
+++ b/packages/runtime/test/server/registry.test.ts
@@ -26,7 +26,18 @@ describe("a registry", () => {
     expect(registry.exists("GET", "/goodbye")).toBe(false);
   });
 
-  it.todo("returns debug information if path does not exist");
+  it("returns a diagnostic 404 response when no handler exists", async () => {
+    const registry = new Registry();
+
+    expect(
+      await registry.endpoint("GET", "/missing")({} as RequestDataWithBody),
+    ).toStrictEqual({
+      body: "Could not find a GET method matching /missing\n",
+      contentType: "text/plain",
+      headers: {},
+      status: 404,
+    });
+  });
 
   it("returns a function matching the URL and request method", async () => {
     const registry = new Registry();

--- a/packages/runtime/test/server/response-builder.test.ts
+++ b/packages/runtime/test/server/response-builder.test.ts
@@ -281,7 +281,9 @@ describe("a response builder", () => {
     });
 
     it("does not log generation options while creating a random response", async () => {
-      const log = jest.spyOn(console, "log").mockImplementation(() => undefined);
+      const log = jest
+        .spyOn(console, "log")
+        .mockImplementation(() => undefined);
 
       try {
         await createResponseBuilder(operation)[200]?.random();

--- a/packages/runtime/test/server/response-builder.test.ts
+++ b/packages/runtime/test/server/response-builder.test.ts
@@ -339,6 +339,34 @@ describe("a response builder", () => {
       expect(response?.headers?.["x-required-header"]).toBe("already-set");
     });
 
+    it("does not duplicate an already-set required header with different casing", async () => {
+      const operationWithRequiredHeaders: OpenApiOperation = {
+        responses: {
+          200: {
+            content: {
+              "application/json": { schema: { type: "object" } },
+            },
+            headers: {
+              "x-required-header": {
+                required: true,
+                schema: { type: "string" },
+              },
+            },
+          },
+        },
+      };
+
+      const response = await createResponseBuilder(
+        operationWithRequiredHeaders,
+      )[200]
+        ?.header("X-Required-Header", "already-set")
+        .random();
+
+      expect(response?.headers).toStrictEqual({
+        "X-Required-Header": "already-set",
+      });
+    });
+
     it("correctly handles alwaysFakeOptionals option", async () => {
       const operationWithoutExamples: OpenApiOperation = {
         responses: {

--- a/packages/runtime/test/server/response-builder.test.ts
+++ b/packages/runtime/test/server/response-builder.test.ts
@@ -1,4 +1,5 @@
 import type { OpenApiOperation } from "@counterfact/types";
+import { jest } from "@jest/globals";
 import type { DispatcherConfig as Config } from "../../src/runtime-config.js";
 import { createResponseBuilder } from "../../src/server/response-builder.js";
 import retry from "jest-retries";
@@ -277,6 +278,18 @@ describe("a response builder", () => {
       //   body: { value: "hello" },
       //   type: "application/json",
       // });
+    });
+
+    it("does not log generation options while creating a random response", async () => {
+      const log = jest.spyOn(console, "log").mockImplementation(() => undefined);
+
+      try {
+        await createResponseBuilder(operation)[200]?.random();
+
+        expect(log).not.toHaveBeenCalled();
+      } finally {
+        log.mockRestore();
+      }
     });
 
     it("fills in required headers when calling random()", async () => {

--- a/packages/runtime/test/server/response-validator.test.ts
+++ b/packages/runtime/test/server/response-validator.test.ts
@@ -102,6 +102,27 @@ describe("validateResponse", () => {
     expect(result.valid).toBe(true);
   });
 
+  it("matches response header names case-insensitively", () => {
+    const result = validateResponse(
+      {
+        responses: {
+          200: {
+            content: {},
+            headers: {
+              "x-trace-id": {
+                required: true,
+                schema: { type: "integer" },
+              },
+            },
+          },
+        },
+      },
+      { body: "ok", headers: { "X-Trace-ID": "42" }, status: 200 },
+    );
+
+    expect(result).toStrictEqual({ errors: [], valid: true });
+  });
+
   it("coerces boolean-typed header strings before validation", () => {
     const result = validateResponse(
       {

--- a/packages/runtime/test/server/web-server/koa-middleware.test.ts
+++ b/packages/runtime/test/server/web-server/koa-middleware.test.ts
@@ -430,6 +430,31 @@ describe("koa middleware", () => {
     expect(ctx.body).toBe("root");
   });
 
+  it("normalizes long trailing-slash prefixes in linear time", async () => {
+    const registry = new Registry();
+    registry.add("/", { GET: () => ({ body: "root" }) });
+
+    const middleware = routesMiddleware(
+      `/api${"/".repeat(100_000)}`,
+      new Dispatcher(registry, new ContextRegistry()),
+      CONFIG,
+    );
+    const ctx = {
+      req: { path: "/api" },
+      request: {
+        headers: {},
+        method: "GET",
+        path: "/api",
+      },
+      set: jest.fn(),
+    } as unknown as ParameterizedContext;
+
+    await middleware(ctx, async () => await Promise.resolve());
+
+    expect(ctx.status).toBe(200);
+    expect(ctx.body).toBe("root");
+  });
+
   it("does not pass a request body for a GET request", async () => {
     const registry = new Registry();
 

--- a/packages/runtime/test/server/web-server/koa-middleware.test.ts
+++ b/packages/runtime/test/server/web-server/koa-middleware.test.ts
@@ -381,6 +381,55 @@ describe("koa middleware", () => {
     expect(ctx.body).toBe("Hello, Homer!");
   });
 
+  it("does not intercept a path that only shares the prefix text", async () => {
+    const registry = new Registry();
+    registry.add("/pets", { GET: () => ({ body: "pets" }) });
+
+    const middleware = routesMiddleware(
+      "/api",
+      new Dispatcher(registry, new ContextRegistry()),
+      CONFIG,
+    );
+    const next = jest.fn(async () => await Promise.resolve());
+    const ctx = {
+      request: {
+        headers: {},
+        method: "GET",
+        path: "/apiary/pets",
+      },
+    } as unknown as ParameterizedContext;
+
+    await middleware(ctx, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(ctx.body).toBeUndefined();
+  });
+
+  it("maps an exact prefix match to the root route", async () => {
+    const registry = new Registry();
+    registry.add("/", { GET: () => ({ body: "root" }) });
+
+    const middleware = routesMiddleware(
+      "/api/",
+      new Dispatcher(registry, new ContextRegistry()),
+      CONFIG,
+    );
+    const ctx = {
+      req: { path: "/api" },
+      request: {
+        headers: {},
+        method: "GET",
+        path: "/api",
+      },
+      set: jest.fn(),
+    } as unknown as ParameterizedContext;
+
+    await middleware(ctx, async () => await Promise.resolve());
+
+    expect(ctx.status).toBe(200);
+    expect(ctx.body).toBe("root");
+  });
+
   it("does not pass a request body for a GET request", async () => {
     const registry = new Registry();
 

--- a/packages/runtime/test/server/web-server/multi-routes-middleware.test.ts
+++ b/packages/runtime/test/server/web-server/multi-routes-middleware.test.ts
@@ -81,6 +81,28 @@ describe("routes middleware for multiple API runners", () => {
     expect(response.text).toBe("products");
   });
 
+  it("does not select a runner when only the prefix text matches", async () => {
+    const app = appFor([
+      runner("/api", [["/pets", { GET: () => ({ body: "pets" }) }]]),
+    ]);
+
+    const response = await request(app.callback()).get("/apiary/pets");
+
+    expect(response.status).toBe(404);
+    expect(response.text).not.toBe("pets");
+  });
+
+  it("maps an exact trailing-slash prefix to the root route", async () => {
+    const app = appFor([
+      runner("/api/", [["/", { GET: () => ({ body: "root" }) }]]),
+    ]);
+
+    const response = await request(app.callback()).get("/api");
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("root");
+  });
+
   it("selects a later runner that supports the requested method", async () => {
     const app = appFor([
       runner("", [["/items", { GET: () => ({ body: "get items" }) }]]),


### PR DESCRIPTION
## Summary

- prevent generated route paths and repository keys from escaping the output directory
- enforce URL segment boundaries and HTTP header case-insensitivity across routing, validation, coercion, and response generation
- safely encode client path parameters, inherit path-item parameters, and distinguish URLs from similarly named local files
- roll back partial startup and attempt every shutdown operation
- restore the no-emit typecheck, activate the missing-route regression test, and isolate REPL test streams

Each publishable behavior fix has its own patch changeset.

## Security impact

OpenAPI paths and repository keys now fail closed before any generated file operation if they are absolute, contain traversal or platform separators, or otherwise cannot be represented safely under the destination.

## Verification

- build, lint, typecheck, package boundaries, publishable-package checks
- 949 unit tests and 127 snapshots
- client, generator, runtime, REPL, OpenAPI, and Counterfact focused suites
- packed consumers and isolated package closures
- 5 black-box developer journeys
- type-definition tests and release preflight
- traced REPL suite with no MaxListeners warning

Native macOS watching hit the host file-descriptor ceiling during the combined suite; the complete suite passed with `CHOKIDAR_USEPOLLING=1`, while package suites passed independently with native watching.
