### PR TITLE
fix(ci): bootstrap release preflight directly

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install trusted-publishing toolchain
         run: npm install --global npm@11.18.0
       - name: Release preflight
-        run: yarn release:preflight
+        run: node scripts/release-preflight.mjs
 
       - name: Create or update the version pull request
         id: changesets


### PR DESCRIPTION
## Summary
- Fix release CI preflight job to run the preflight script directly so Yarn bootstrap happens in-process before checks.
- Resolves missing install-state in GitHub Actions release workflow.

## Validation
- Verified on temp run: Yarn install + release preflight checks pass and no publish occurs.
